### PR TITLE
Fixed IPv6 address parsing to handle IPv6: prefix

### DIFF
--- a/session.go
+++ b/session.go
@@ -174,6 +174,8 @@ func (m *serverSession) Process(msg *wire.Message) (*Response, error) {
 				if addr != nil {
 					address = addr.String()
 				}
+			} else if strings.HasPrefix(address, "IPv6:") {
+				addr = net.ParseIP(address[5:])
 			} else {
 				addr = net.ParseIP(address)
 			}

--- a/session.go
+++ b/session.go
@@ -176,6 +176,9 @@ func (m *serverSession) Process(msg *wire.Message) (*Response, error) {
 				}
 			} else if strings.HasPrefix(address, "IPv6:") {
 				addr = net.ParseIP(address[5:])
+				if addr != nil {
+					address = addr.String()
+				}
 			} else {
 				addr = net.ParseIP(address)
 			}

--- a/session_test.go
+++ b/session_test.go
@@ -260,7 +260,7 @@ func Test_milterSession_Process(t *testing.T) {
 			check: func(t *testing.T, s *serverSession) {
 				p := s.backend.(*processTestMilter)
 				if p.family != "tcp6" {
-					t.Errorf("expected tcp4, got %q", p.family)
+					t.Errorf("expected tcp6, got %q", p.family)
 				}
 				if p.addr != "::" {
 					t.Errorf("expected ::, got %q", p.addr)
@@ -278,7 +278,7 @@ func Test_milterSession_Process(t *testing.T) {
 			check: func(t *testing.T, s *serverSession) {
 				p := s.backend.(*processTestMilter)
 				if p.family != "tcp6" {
-					t.Errorf("expected tcp4, got %q", p.family)
+					t.Errorf("expected tcp6, got %q", p.family)
 				}
 				if p.addr != "::" {
 					t.Errorf("expected ::, got %q", p.addr)
@@ -291,6 +291,24 @@ func Test_milterSession_Process(t *testing.T) {
 				}
 			},
 		}, &wire.Message{wire.CodeConn, []byte{'h', 0, '6', 9, 251, '[', ':', ':', ']', 0}}, cont, false},
+		{"conn tcp6 protocol 3", fields{
+			backend: &processTestMilter{},
+			check: func(t *testing.T, s *serverSession) {
+				p := s.backend.(*processTestMilter)
+				if p.family != "tcp6" {
+					t.Errorf("expected tcp6, got %q", p.family)
+				}
+				if p.addr != "::1" {
+					t.Errorf("expected ::1, got %q", p.addr)
+				}
+				if p.port != 2555 {
+					t.Errorf("expected 2555, got %v", p.port)
+				}
+				if p.host != "h" {
+					t.Errorf("expected \"h\", got %q", p.host)
+				}
+			},
+		}, &wire.Message{wire.CodeConn, []byte{'h', 0, '6', 9, 251, 'I', 'P', 'v', '6', ':', '0', ':', '0', ':', '0', ':', '0', ':', '0', ':', '0', ':', '0', ':', '1', 0}}, cont, false},
 		{"conn tcp6 protocol err", fields{
 			backend: &processTestMilter{},
 		}, &wire.Message{wire.CodeConn, []byte{'h', 0, '6', 9, 251, '[', '@', ']', 0}}, nil, true},


### PR DESCRIPTION
Hi!

When using go-milter in an IPv6 address environment, there may be cases where net.ParseIP fails and an error is generated. Upon investigation, it was found that the address string passed to net.ParseIP contains the IPv6 prefix, IPv6:2409:....

When sending mail to loopback address ::1 from the local environment, the following debug print statement was added:

```
address = wire.ReadCString(msg.Data)
log.Printf("milter: conn: address=%s", address)
```

The output showed that the address string contained the IPv6: prefix:

```
milter: conn: address=IPv6:0:0:0:0:0:0:0:1
```

To solve this issue, we removed the IPv6: prefix from the address string before passing it to net.ParseIP.