### PR TITLE
Header Unfolding & SetAddressList formatting

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -69,10 +69,10 @@ You need docker since the test are run inside a docker container.
 
 Add a Makefile
 ```makefile
-GO_MILTER_DIR := $(shell go list -f '{{.Dir}}' github.com/d--j/go-milter)
+GO_MILTER_INTEGRATION_DIR := $(shell cd integration && go list -f '{{.Dir}}' github.com/d--j/go-milter/integration)
 
 integration:
-	docker build -q --progress=plain -t go-milter-integration "$(GO_MILTER_DIR)/integration/docker" && \
+	docker build -q -t go-milter-integration "$(GO_MILTER_INTEGRATION_DIR)/docker" && \
 	docker run --rm -w /usr/src/root/integration -v $(PWD):/usr/src/root go-milter-integration \
 	go run github.com/d--j/go-milter/integration/runner -filter '.*' ./tests
 

--- a/integration/tests/header/change-to.testcase
+++ b/integration/tests/header/change-to.testcase
@@ -1,0 +1,18 @@
+FROM <change-to@example.com>
+HEADER
+From: <>
+To: <to@example.com>
+Subject: test
+Date: Fri, 10 Mar 2023 23:29:35 +0000 (UTC)
+Message-ID: <id@example.com>
+.
+DECISION ACCEPT
+HEADER
+Received: placeholder
+From: <>
+To: <to@example.com>,
+ <to@example.org>
+Subject: test
+Date: Fri, 10 Mar 2023 23:29:35 +0000 (UTC)
+Message-ID: <id@example.com>
+.

--- a/integration/tests/header/test.go
+++ b/integration/tests/header/test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/d--j/go-milter/integration"
 	"github.com/d--j/go-milter/mailfilter"
+	"github.com/emersion/go-message/mail"
 )
 
 func main() {
@@ -57,6 +58,13 @@ func main() {
 			}
 			trx.Headers().Add("X-ADD1", "Test")
 			trx.Headers().Add("X-ADD2", "Test")
+		case "change-to@example.com":
+			addr, err := trx.Headers().AddressList("To")
+			if err != nil {
+				return nil, err
+			}
+			addr = append(addr, &mail.Address{Address: "to@example.org"})
+			trx.Headers().SetAddressList("To", addr)
 		default:
 			return mailfilter.CustomErrorResponse(500, "unknown mail from"), nil
 		}

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -20,6 +20,14 @@ func unfold(lines string) string {
 	return unfoldRegex.ReplaceAllString(lines, " ")
 }
 
+func formatAddressList(l []*mail.Address) string {
+	formatted := make([]string, len(l))
+	for i, a := range l {
+		formatted[i] = a.String()
+	}
+	return strings.Join(formatted, ",\r\n ")
+}
+
 type Field struct {
 	Index        int
 	CanonicalKey string
@@ -169,11 +177,7 @@ func (h *Header) SetText(key string, value string) {
 }
 
 func (h *Header) SetAddressList(key string, addresses []*mail.Address) {
-	if h.helper == nil {
-		h.helper = newHelper()
-	}
-	h.helper.SetAddressList(helperKey, addresses)
-	h.Set(key, h.helper.Get(helperKey))
+	h.Set(key, formatAddressList(addresses))
 }
 
 func (h *Header) Subject() (string, error) {
@@ -309,8 +313,7 @@ func (f *Fields) SetText(value string) {
 }
 
 func (f *Fields) addressList(value []*mail.Address) string {
-	f.helper.SetAddressList(helperKey, value)
-	return f.helper.Get(helperKey)
+	return formatAddressList(value)
 }
 
 func (f *Fields) SetAddressList(value []*mail.Address) {

--- a/internal/header/header_test.go
+++ b/internal/header/header_test.go
@@ -254,8 +254,8 @@ func TestHeaderFields_GetText(t *testing.T) {
 
 func outputFields(fields []*Field) string {
 	h := Header{fields: fields}
-	bytes, _ := io.ReadAll(h.Reader())
-	return string(bytes)
+	b, _ := io.ReadAll(h.Reader())
+	return string(b)
 }
 
 func TestHeaderFields_InsertAfter(t *testing.T) {
@@ -566,7 +566,7 @@ func TestHeaderFields_SetAddressList(t *testing.T) {
 		want   *Field
 	}{
 		{"One", fields{0, testHeader()}, args{[]*mail.Address{&nobody}}, &Field{0, "From", []byte("From: <nobody@localhost>")}},
-		{"Two", fields{1, testHeader()}, args{[]*mail.Address{&nobody, &root}}, &Field{1, "To", []byte("To: <nobody@localhost>, <root@localhost>")}},
+		{"Two", fields{1, testHeader()}, args{[]*mail.Address{&nobody, &root}}, &Field{1, "To", []byte("To: <nobody@localhost>,\r\n <root@localhost>")}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -578,7 +578,7 @@ func TestHeaderFields_SetAddressList(t *testing.T) {
 			f.SetAddressList(tt.args.value)
 			got := f.h.fields[f.index()]
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SetAddressList() = %v, want %v", got, tt.want)
+				t.Errorf("SetAddressList() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/mailfilter/header/header.go
+++ b/mailfilter/header/header.go
@@ -15,6 +15,9 @@ type Header interface {
 	// Value returns the value of the first field which canonical key is equal to the canonical version of key.
 	// Returns the empty string when key was not found in header.
 	Value(key string) string
+	// UnfoldedValue returns the unfolded value (newlines replaced with spaces) of the first field which canonical key is equal to the canonical version of key.
+	// Returns the empty string when key was not found in header.
+	UnfoldedValue(key string) string
 	// Text returns the decoded value of the first field which canonical key is equal to the canonical version of key.
 	// Returns the empty string and no error when key was not found in header.
 	Text(key string) (string, error)
@@ -74,6 +77,9 @@ type Fields interface {
 	// Value returns the raw value of the current header field.
 	// Panics when called before calling Next or when Next returned false.
 	Value() string
+	// UnfoldedValue returns the unfolded value (newlines replaced with spaces) of the current header field.
+	// Panics when called before calling Next or when Next returned false.
+	UnfoldedValue() string
 	// Text returns the decoded text of the current header field.
 	// An error is returned when the text could not be decoded (e.g. because the charset is unknown).
 	// Panics when called before calling Next or when Next returned false.

--- a/mailfilter/header/header.go
+++ b/mailfilter/header/header.go
@@ -32,6 +32,7 @@ type Header interface {
 	// If key was not found, this a new header field gets added.
 	SetText(key string, value string)
 	// SetAddressList sets the value of the first header field with the canonical key "key" to "value" (encoded as address list).
+	// The address list is encoded as multi-line header field when the MTA supports this (Sendmail does not).
 	// If key was not found, this a new header field gets added.
 	SetAddressList(key string, addresses []*mail.Address)
 	// Subject returns the decoded value of the Subject field.
@@ -94,6 +95,7 @@ type Fields interface {
 	// Panics when called before calling Next or when Next returned false.
 	SetText(value string)
 	// SetAddressList sets the value of the current header field as address list value.
+	// The value is encoded as multi-line header field when the MTA supports this (Sendmail does not).
 	// Panics when called before calling Next or when Next returned false.
 	SetAddressList(value []*mail.Address)
 	// Del marks the current header field as deleted.
@@ -109,6 +111,7 @@ type Fields interface {
 	// Panics when called before calling Next or when Next returned false.
 	ReplaceText(key string, value string)
 	// ReplaceAddressList replaces the current field with a new field with key and value.
+	// The value is encoded as multi-line header field when the MTA supports this (Sendmail does not).
 	// Panics when called before calling Next or when Next returned false.
 	ReplaceAddressList(key string, value []*mail.Address)
 	// InsertBefore adds a new field in front of the current field with key and value (as-is).
@@ -118,6 +121,7 @@ type Fields interface {
 	// Panics when called before calling Next or when Next returned false.
 	InsertTextBefore(key string, value string)
 	// InsertAddressListBefore adds a new field in front of the current field with key and value.
+	// The value is encoded as multi-line header field when the MTA supports this (Sendmail does not).
 	// Panics when called before calling Next or when Next returned false.
 	InsertAddressListBefore(key string, value []*mail.Address)
 	// InsertAfter adds a new field after the current field with key and value (as-is).
@@ -127,6 +131,7 @@ type Fields interface {
 	// Panics when called before calling Next or when Next returned false.
 	InsertTextAfter(key string, value string)
 	// InsertAddressListAfter adds a new field after the current field with key and value.
+	// The value is encoded as multi-line header field when the MTA supports this (Sendmail does not).
 	// Panics when called before calling Next or when Next returned false.
 	InsertAddressListAfter(key string, value []*mail.Address)
 }


### PR DESCRIPTION
Add UnfoldedValue() method that returns the unfolded version of a header value.

[mail.ParseAddressList](https://pkg.go.dev/net/mail#ParseAddressList) cannot handle folded header values so the AddressList() methods would return errors for perfectly valid address lists (that had newlines in them).

While we are at it, we also change the formatting of address lists to encode them as multi-line header fields (one address per line).