### PR TITLE
Enforce Header Order for Sendmail

### DIFF
--- a/integration/mta/mock/mta.go
+++ b/integration/mta/mock/mta.go
@@ -338,6 +338,8 @@ func (s *Session) Data(r io.Reader) error {
 			}
 			if act.HeaderIndex == 0 {
 				headers = append([]*field{f}, headers...)
+			} else if act.HeaderIndex == 1 { // special case: skip our received line
+				headers = append(headers[:1], append([]*field{f}, headers[1:]...)...)
 			} else if len(headers) < int(act.HeaderIndex)-1 {
 				headers = append(headers, f)
 			} else {

--- a/integration/tests/header/add-first.testcase
+++ b/integration/tests/header/add-first.testcase
@@ -19,9 +19,9 @@ DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com;
 .
 DECISION ACCEPT
 HEADER
+Received: placeholder
 X-First1: Test
 X-First2: Test
-Received: placeholder
 From: <>
 To: <to@example.com>
 Subject: test

--- a/integration/tests/header/multi.testcase
+++ b/integration/tests/header/multi.testcase
@@ -8,9 +8,9 @@ Message-ID: <id@example.com>
 .
 DECISION ACCEPT
 HEADER
+Received: placeholder
 X-First1: Test
 X-First2: Test
-Received: placeholder
 From: <>
 To: <to@example.com>
 X-Before-DATE: Test

--- a/integration/tests/header/test.go
+++ b/integration/tests/header/test.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	integration.Test(func(ctx context.Context, trx mailfilter.Trx) (mailfilter.Decision, error) {
+		trx.HeadersEnforceOrder()
 		switch trx.MailFrom().Addr {
 		case "add@example.com":
 			trx.Headers().Add("X-ADD1", "Test")

--- a/internal/header/diff_test.go
+++ b/internal/header/diff_test.go
@@ -24,7 +24,7 @@ func outputDiff(diff []fieldDiff) string {
 	return s.String()
 }
 
-func Test_diffHeaderFields(t *testing.T) {
+func Test_diffFields(t *testing.T) {
 	orig := testHeader()
 	addOne := testHeader()
 	addOne.Add("X-Test", "1")
@@ -91,7 +91,7 @@ func Test_diffHeaderFields(t *testing.T) {
 	}
 }
 
-func Test_calculateHeaderModifications(t *testing.T) {
+func TestDiff(t *testing.T) {
 	orig := testHeader()
 	addOne := testHeader()
 	addOne.Add("X-Test", "1")
@@ -123,9 +123,9 @@ func Test_calculateHeaderModifications(t *testing.T) {
 	}{
 		{"equal", args{orig, orig}, nil, nil},
 		{"add-one", args{orig, addOne}, nil, []Op{{Index: 5, Name: "X-Test", Value: " 1"}}},
-		{"add-one-in-front", args{orig, addOneInFront}, []Op{{Kind: KindInsert, Index: 0, Name: "X-Test", Value: " 1"}}, nil},
+		{"add-one-in-front", args{orig, addOneInFront}, []Op{{Kind: KindInsert, Index: 1, Name: "X-Test", Value: " 1"}}, nil},
 		{"complex", args{orig, complexChanges}, []Op{
-			{Kind: KindInsert, Index: 0, Name: "X-Test", Value: " 1"},
+			{Kind: KindInsert, Index: 1, Name: "X-Test", Value: " 1"},
 			{Kind: KindInsert, Index: 2, Name: "X-Test", Value: " 1"},
 			{Kind: KindInsert, Index: 2, Name: "X-Test", Value: " 1"},
 			{Kind: KindInsert, Index: 3, Name: "X-Test", Value: " 1"},
@@ -143,10 +143,114 @@ func Test_calculateHeaderModifications(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotChangeInsertOps, gotAddOps := Diff(tt.args.orig, tt.args.changed)
 			if !reflect.DeepEqual(gotChangeInsertOps, tt.wantChangeInsertOps) {
-				t.Errorf("calculateHeaderModifications() gotChangeInsertOps = %+v, want %+v", gotChangeInsertOps, tt.wantChangeInsertOps)
+				t.Errorf("Diff() gotChangeInsertOps = %+v, want %+v", gotChangeInsertOps, tt.wantChangeInsertOps)
 			}
 			if !reflect.DeepEqual(gotAddOps, tt.wantAddOps) {
-				t.Errorf("calculateHeaderModifications() gotAddOps = %+v, want %+v", gotAddOps, tt.wantAddOps)
+				t.Errorf("Diff() gotAddOps = %+v, want %+v", gotAddOps, tt.wantAddOps)
+			}
+		})
+	}
+}
+
+func TestRecreate(t *testing.T) {
+	orig := testHeader()
+	addOne := testHeader()
+	addOne.Add("X-Test", "1")
+	delFirst := testHeader()
+	delFirstF := delFirst.Fields()
+	delFirstF.Next()
+	delFirstF.Del()
+	type args struct {
+		orig    *Header
+		changed *Header
+	}
+	tests := []struct {
+		name                string
+		args                args
+		wantChangeInsertOps []Op
+		wantAddOps          []Op
+	}{
+		{"equal", args{orig, orig}, []Op{
+			{Kind: KindChange, Index: 1, Name: "From", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "To", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "subject", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "DATE", Value: ""},
+		}, []Op{
+			{Index: 0, Name: "From", Value: " <root@localhost>"},
+			{Index: 1, Name: "To", Value: "  <root@localhost>, <nobody@localhost>"},
+			{Index: 2, Name: "subject", Value: " =?UTF-8?Q?=F0=9F=9F=A2?="},
+			{Index: 3, Name: "DATE", Value: "\tWed, 01 Mar 2023 15:47:33 +0100"},
+		}},
+		{"add-one", args{orig, addOne}, []Op{
+			{Kind: KindChange, Index: 1, Name: "From", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "To", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "subject", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "DATE", Value: ""},
+		}, []Op{
+			{Index: 0, Name: "From", Value: " <root@localhost>"},
+			{Index: 1, Name: "To", Value: "  <root@localhost>, <nobody@localhost>"},
+			{Index: 2, Name: "subject", Value: " =?UTF-8?Q?=F0=9F=9F=A2?="},
+			{Index: 3, Name: "DATE", Value: "\tWed, 01 Mar 2023 15:47:33 +0100"},
+			{Index: 4, Name: "X-Test", Value: " 1"},
+		}},
+		{"del-first", args{orig, delFirst}, []Op{
+			{Kind: KindChange, Index: 1, Name: "From", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "To", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "subject", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "DATE", Value: ""},
+		}, []Op{
+			{Index: 0, Name: "To", Value: "  <root@localhost>, <nobody@localhost>"},
+			{Index: 1, Name: "subject", Value: " =?UTF-8?Q?=F0=9F=9F=A2?="},
+			{Index: 2, Name: "DATE", Value: "\tWed, 01 Mar 2023 15:47:33 +0100"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChangeInsertOps, gotAddOps := Recreate(tt.args.orig, tt.args.changed)
+			if !reflect.DeepEqual(gotChangeInsertOps, tt.wantChangeInsertOps) {
+				t.Errorf("Recreate() gotChangeInsertOps = %+v, want %+v", gotChangeInsertOps, tt.wantChangeInsertOps)
+			}
+			if !reflect.DeepEqual(gotAddOps, tt.wantAddOps) {
+				t.Errorf("Recreate() gotAddOps = %+v, want %+v", gotAddOps, tt.wantAddOps)
+			}
+		})
+	}
+}
+
+func TestDiffOrRecreate(t *testing.T) {
+	orig := testHeader()
+	type args struct {
+		recreate bool
+		orig     *Header
+		changed  *Header
+	}
+	tests := []struct {
+		name                string
+		args                args
+		wantChangeInsertOps []Op
+		wantAddOps          []Op
+	}{
+		{"diff", args{false, orig, orig}, nil, nil},
+		{"recreate", args{true, orig, orig}, []Op{
+			{Kind: KindChange, Index: 1, Name: "From", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "To", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "subject", Value: ""},
+			{Kind: KindChange, Index: 1, Name: "DATE", Value: ""},
+		}, []Op{
+			{Index: 0, Name: "From", Value: " <root@localhost>"},
+			{Index: 1, Name: "To", Value: "  <root@localhost>, <nobody@localhost>"},
+			{Index: 2, Name: "subject", Value: " =?UTF-8?Q?=F0=9F=9F=A2?="},
+			{Index: 3, Name: "DATE", Value: "\tWed, 01 Mar 2023 15:47:33 +0100"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChangeInsertOps, gotAddOps := DiffOrRecreate(tt.args.recreate, tt.args.orig, tt.args.changed)
+			if !reflect.DeepEqual(gotChangeInsertOps, tt.wantChangeInsertOps) {
+				t.Errorf("DiffOrRecreate() gotChangeInsertOps = %+v, want %+v", gotChangeInsertOps, tt.wantChangeInsertOps)
+			}
+			if !reflect.DeepEqual(gotAddOps, tt.wantAddOps) {
+				t.Errorf("DiffOrRecreate() gotAddOps = %+v, want %+v", gotAddOps, tt.wantAddOps)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a workaround for Sendmail that can enforce the order of the header fields.