### PR TITLE
Fix Index Out of Range Panic in CrLfToLfTransformer

### DIFF
--- a/milterutil/transformer.go
+++ b/milterutil/transformer.go
@@ -22,7 +22,6 @@ func (t *CrLfToLfTransformer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc
 		if c == lf {
 			if t.prevCR {
 				nSrc++
-				dst[nDst-1] = lf
 				t.prevCR = false
 				continue
 			}

--- a/milterutil/transformer_test.go
+++ b/milterutil/transformer_test.go
@@ -93,6 +93,8 @@ func TestCrLfToLfTransformer(t *testing.T) {
 		{[]string{"\r", "\n"}, "\n"},
 		{[]string{"\r\r", "\n"}, "\n\n"},
 		{[]string{stuffing + "123456\r", "\n"}, stuffing + "123456\n"},
+		// regression https://github.com/d--j/go-milter/pull/20
+		{[]string{"aaaaaaaaaaaaaaaaaaaaaaaa\r\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\nbbbbbbb"}, "aaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nbbbbbbb"},
 	})
 }
 


### PR DESCRIPTION
Hi.

I've encountered an "index out of range" panic in the CrLfToLfTransformer.Transform method of the github.com/d--j/go-milter/milterutil package. This issue arises when a \r\n sequence appears at the boundary of the src slice during transformation, leading to an attempt to access an invalid index in dst.

The current implementation seems to anticipate carriage returns (\r) and replaces them with line feeds (\n). However, when \r\n is split across the boundary of src, it results in dst[nDst-1] accessing an out-of-range index.


``` go
package main

import (
        "fmt"

        "github.com/d--j/go-milter/milterutil"
)

func main() {
        s := "aaaaaaaaaaaaaaaaaaaaaaaa\r\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\nbbbbbbb"

        a := milterutil.CrLfToLf(s)
        fmt.Println(a)
}
```

```
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/d--j/go-milter/milterutil.(*CrLfToLfTransformer).Transform(0xc000006101?, {0xc00010c180?, 0x433c92?, 0x5198e8?}, {0xc00010c080?, 0xc00007cf70?, 0x440991?}, 0xa0?)
        /root/go/pkg/mod/github.com/d--j/go-milter@v0.8.3/milterutil/transformer.go:25 +0x10f
golang.org/x/text/transform.String({0x4b9288, 0xc000018090}, {0x4a3189, 0x89})
        /root/go/pkg/mod/golang.org/x/text@v0.9.0/transform/transform.go:652 +0x842
github.com/d--j/go-milter/milterutil.CrLfToLf(...)
        /root/go/pkg/mod/github.com/d--j/go-milter@v0.8.3/milterutil/transformer.go:61
main.main()
        /root/work/hoge/hoge.go:12 +0x45
exit status 2
```

I have revised the existing code in the CrLfToLfTransformer.Transform method to address an issue with index out of range errors. It appears that carriage returns (\r) are already being transformed into line feeds (\n) in the existing code. Therefore, I have removed the line `dst[nDst-1] = lf`, as it seemed unnecessary and was causing the index out of range issue.

``` go
t.prevCR = c == cr
if t.prevCR {
    c = lf
}
dst[nDst] = c
```

Could you please review this change and confirm if it aligns with the intended behavior and resolves the identified issue?
