### PR TITLE
Extended Error Codes fixes & Graceful Shutdown

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1659,7 +1659,7 @@ func TestMilterClient_WithMockServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer session.Close()
+			t.Cleanup(func() { _ = session.Close() })
 			for i, op := range ltt.ops {
 				t.Logf("%q op %d", ltt.name, i)
 				if op.s1 != nil {

--- a/example_server_test.go
+++ b/example_server_test.go
@@ -1,9 +1,14 @@
 package milter_test
 
 import (
+	"context"
 	"log"
 	"net"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/d--j/go-milter"
 )
@@ -44,12 +49,23 @@ func ExampleServer() {
 	wgDone.Add(1)
 	go func(socket net.Listener) {
 		if err := server.Serve(socket); err != nil {
-			log.Fatal(err)
+			log.Println(err)
 		}
 		wgDone.Done()
 	}(socket)
 
 	log.Printf("Started milter on %s:%s", socket.Addr().Network(), socket.Addr().String())
+
+	// wait for SIGINT or SIGTERM
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		log.Printf("Gracefully shutting down milter…")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		server.Shutdown(ctx)
+	}()
 
 	// quit when milter quits
 	wgDone.Wait()

--- a/integration/mta/mock/mta.go
+++ b/integration/mta/mock/mta.go
@@ -355,7 +355,7 @@ func (s *Session) Data(r io.Reader) error {
 			if len(act.HeaderValue) == 0 || (act.HeaderValue[0] != ' ' && act.HeaderValue[0] != '\t') {
 				maybeSpace = " "
 			}
-			raw := fmt.Sprintf("%s:%s%s\r\n", act.HeaderName, maybeSpace, act.HeaderValue)
+			raw := fmt.Sprintf("%s:%s%s\r\n", act.HeaderName, maybeSpace, headerValue(act.HeaderValue))
 			headers = append(headers, &field{
 				key:       textproto.CanonicalMIMEHeaderKey(act.HeaderName),
 				changeIdx: -1,
@@ -367,7 +367,7 @@ func (s *Session) Data(r io.Reader) error {
 			if len(act.HeaderValue) == 0 || (act.HeaderValue[0] != ' ' && act.HeaderValue[0] != '\t') {
 				maybeSpace = " "
 			}
-			raw := fmt.Sprintf("%s:%s%s\r\n", act.HeaderName, maybeSpace, act.HeaderValue)
+			raw := fmt.Sprintf("%s:%s%s\r\n", act.HeaderName, maybeSpace, headerValue(act.HeaderValue))
 			f := &field{
 				key:       textproto.CanonicalMIMEHeaderKey(act.HeaderName),
 				changeIdx: -1,
@@ -389,7 +389,7 @@ func (s *Session) Data(r io.Reader) error {
 			if len(act.HeaderValue) == 0 || (act.HeaderValue[0] != ' ' && act.HeaderValue[0] != '\t') {
 				maybeSpace = " "
 			}
-			raw := fmt.Sprintf("%s:%s%s\r\n", act.HeaderName, maybeSpace, act.HeaderValue)
+			raw := fmt.Sprintf("%s:%s%s\r\n", act.HeaderName, maybeSpace, headerValue(act.HeaderValue))
 			key := textproto.CanonicalMIMEHeaderKey(act.HeaderName)
 			for _, f := range headers {
 				if f.key == key && f.changeIdx == int(act.HeaderIndex) {
@@ -450,6 +450,19 @@ type field struct {
 	key       string
 	changeIdx int
 	raw       []byte
+}
+
+func headerValue(s string) []byte {
+	in := []byte(s)
+	out := make([]byte, 0, len(in))
+	l := len(in)
+	for i := 0; i < l; i++ {
+		out = append(out, in[i])
+		if in[i] == '\n' && i+1 < l && (in[i+1] != ' ' && in[i+1] != '\t') {
+			out = append(out, '\t')
+		}
+	}
+	return out
 }
 
 func splitHeaders(headerBytes []byte) (fields []*field) {

--- a/integration/testcase.go
+++ b/integration/testcase.go
@@ -751,9 +751,10 @@ func DiffOutput(expected, got *Output) (string, bool) {
 }
 
 var unfoldRegex = regexp.MustCompile(`\r?\n\s*`)
+var unfoldRegex2 = regexp.MustCompile(` \t`)
 
 func unfold(in []byte) []byte {
-	return unfoldRegex.ReplaceAll(in, []byte(" "))
+	return unfoldRegex2.ReplaceAll(unfoldRegex.ReplaceAll(in, []byte(" ")), []byte(" "))
 }
 
 // CompareOutputSendmail is a relaxed compare function that does only check

--- a/integration/tests/header/multiline.testcase
+++ b/integration/tests/header/multiline.testcase
@@ -1,0 +1,20 @@
+FROM <multiline@example.com>
+HEADER
+From: <>
+To: <to@example.com>
+Subject: test
+Date: Fri, 10 Mar 2023 23:29:35 +0000 (UTC)
+Message-ID: <id@example.com>
+.
+DECISION ACCEPT
+HEADER
+Received: placeholder
+From: <>
+To: <to@example.com>
+Subject: test
+Date: Fri, 10 Mar 2023 23:29:35 +0000 (UTC)
+Message-ID: <id@example.com>
+X-MultiLine: Line1
+	Line2
+	Line3
+.

--- a/integration/tests/header/test.go
+++ b/integration/tests/header/test.go
@@ -59,6 +59,8 @@ func main() {
 			}
 			trx.Headers().Add("X-ADD1", "Test")
 			trx.Headers().Add("X-ADD2", "Test")
+		case "multiline@example.com":
+			trx.Headers().Add("X-MultiLine", "Line1\n\tLine2\n\tLine3")
 		case "change-to@example.com":
 			addr, err := trx.Headers().AddressList("To")
 			if err != nil {

--- a/internal/body/err.go
+++ b/internal/body/err.go
@@ -1,0 +1,10 @@
+package body
+
+// ErrReader is an io.Reader that always returns an error.
+type ErrReader struct {
+	Err error
+}
+
+func (e ErrReader) Read(_ []byte) (n int, err error) {
+	return 0, e.Err
+}

--- a/internal/body/err_test.go
+++ b/internal/body/err_test.go
@@ -1,0 +1,37 @@
+package body
+
+import (
+	"io"
+	"testing"
+)
+
+func TestErrReader_Read(t *testing.T) {
+	type fields struct {
+		Err error
+	}
+	type args struct {
+		p []byte
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{"Test1", fields{Err: io.ErrUnexpectedEOF}, args{p: []byte{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := ErrReader{
+				Err: tt.fields.Err,
+			}
+			gotN, err := e.Read(tt.args.p)
+			if err == nil {
+				t.Errorf("Read() error = %v, wantErr %v", err, true)
+				return
+			}
+			if gotN != 0 {
+				t.Errorf("Read() gotN = %v, want %v", gotN, 0)
+			}
+		})
+	}
+}

--- a/internal/header/diff_test.go
+++ b/internal/header/diff_test.go
@@ -50,9 +50,9 @@ func Test_diffFields(t *testing.T) {
 			fields.Replace("X-Test", "1")
 		}
 	}
-	xTest := Field{-1, "X-Test", []byte("X-Test: 1")}
-	subjectChanged := Field{2, "Subject", []byte("subject: changed")}
-	dateDel := Field{3, "Date", []byte("DATE:")}
+	xTest := Field{-1, "X-Test", []byte("X-Test: 1"), false}
+	subjectChanged := Field{2, "Subject", []byte("subject: changed"), false}
+	dateDel := Field{3, "Date", []byte("DATE:"), false}
 
 	type args struct {
 		orig    []*Field

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -171,6 +172,29 @@ func TestWritePacket(t *testing.T) {
 			}
 			if !bytes.Equal(resp.data, ltt.want) {
 				t.Errorf("read data mismatch got = %+v, want %+v", resp.data, ltt.want)
+			}
+		})
+	}
+}
+
+func TestAppendUint16(t *testing.T) {
+	type args struct {
+		dest []byte
+		val  uint16
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{"Empty", args{[]byte{}, 0x1234}, []byte{0x12, 0x34}},
+		{"Nil", args{nil, 0x1234}, []byte{0x12, 0x34}},
+		{"Append", args{[]byte{0, 0}, 0x1234}, []byte{0, 0, 0x12, 0x34}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendUint16(tt.args.dest, tt.args.val); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppendUint16() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/mailfilter/decision.go
+++ b/mailfilter/decision.go
@@ -2,30 +2,42 @@ package mailfilter
 
 import (
 	"github.com/d--j/go-milter/milterutil"
-	"strconv"
 )
 
 type Decision interface {
-	getCode() uint16
-	getReason() string
+	// String returns the decision as an SMTP response string.
+	// This is useful for testing/logging.
+	String() string
+	// Equal returns true if the decision is semantically equal to the provided decision.
+	// This is useful for testing.
+	// As a special case, a QuarantineResponse is equal to Accept.
+	Equal(Decision) bool
 }
 
+// decision is a string backed Decision implementation that gets translated to the default milter responses
+// milter.RespAccept, milter.RespReject, milter.RespTempFail, milter.RespDiscard.
 type decision string
 
-func (d decision) getCode() uint16 {
-	c, _ := strconv.ParseUint(string(d[:3]), 10, 16)
-	return uint16(c)
+func (d decision) String() string {
+	return string(d)
 }
 
-func (d decision) getReason() string {
-	return string(d[4:])
+func (d decision) Equal(d2 Decision) bool {
+	return d2 != nil && d.String() == d2.String()
 }
+
+var _ Decision = (*decision)(nil)
 
 const (
-	Accept   decision = "250 accept"
-	Reject   decision = "550 5.7.1 Command rejected"
+	// Accept is a decision that tells the MTA to accept the message (milter.RespAccept).
+	Accept decision = "250 accept"
+	// Reject is a decision that tells the MTA to reject the message (milter.RespReject).
+	Reject decision = "550 5.7.1 Command rejected"
+	// TempFail is a decision that tells the MTA to temporarily fail the message (milter.RespTempFail).
 	TempFail decision = "451 4.7.1 Service unavailable - try again later"
-	Discard  decision = "250 discard"
+	// Discard is a decision that tells the MTA to discard the message (milter.RespDiscard).
+	// The SMTP client does not get notified about this decision and must assume that the SMTP message was successfully delivered.
+	Discard decision = "250 discard"
 )
 
 type customResponse struct {
@@ -33,12 +45,16 @@ type customResponse struct {
 	reason string
 }
 
-func (c customResponse) getCode() uint16 {
-	return c.code
+func (c customResponse) String() string {
+	formatted, err := milterutil.FormatResponse(c.code, c.reason)
+	if err != nil {
+		panic(err)
+	}
+	return formatted
 }
 
-func (c customResponse) getReason() string {
-	return c.reason
+func (c customResponse) Equal(d Decision) bool {
+	return d != nil && c.String() == d.String()
 }
 
 // CustomErrorResponse can get used to send a custom error response to the client.
@@ -49,7 +65,7 @@ func (c customResponse) getReason() string {
 //
 //	CustomErrorResponse(550, "5.7.1 Command rejected\nContact support")
 //
-// will result in:
+// will result in this SMTP response:
 //
 //	550-5.7.1 Command rejected\r\n
 //	550 5.7.1 Contact support
@@ -64,12 +80,12 @@ type quarantineResponse struct {
 	reason string
 }
 
-func (c quarantineResponse) getCode() uint16 {
-	return 250
+func (c quarantineResponse) String() string {
+	return Accept.String()
 }
 
-func (c quarantineResponse) getReason() string {
-	return "accept (quarantined)"
+func (c quarantineResponse) Equal(d Decision) bool {
+	return d != nil && c.String() == d.String()
 }
 
 // QuarantineResponse can get used to quarantine a message.

--- a/mailfilter/decision.go
+++ b/mailfilter/decision.go
@@ -1,7 +1,6 @@
 package mailfilter
 
 import (
-	"fmt"
 	"github.com/d--j/go-milter/milterutil"
 	"strconv"
 )
@@ -70,19 +69,13 @@ func (c quarantineResponse) getCode() uint16 {
 }
 
 func (c quarantineResponse) getReason() string {
-	if c.reason == "" {
-		return "accept (quarantined)"
-	}
-	if eecEnd := milterutil.FindEnhancedErrorCodeEnd([]byte(c.reason), 250); eecEnd != -1 {
-		return c.reason
-	}
-	return fmt.Sprintf("accept (quarantined: %q)", c.reason)
+	return "accept (quarantined)"
 }
 
 // QuarantineResponse can get used to quarantine a message.
-// The reason can contain new-lines and can start with a valid RFC 2034 extended error code.
-// The extended error code must have a class of "2".
-// See CustomErrorResponse for more information.
+// The message will be accepted but quarantined.
+// You cannot provide extended error codes or multiline responses, since reason will be used as the quarantine reason and
+// will not be passed to the client.
 func QuarantineResponse(reason string) Decision {
 	return &quarantineResponse{
 		reason: reason,

--- a/mailfilter/decision_test.go
+++ b/mailfilter/decision_test.go
@@ -148,9 +148,9 @@ func Test_quarantineResponse_getReason(t *testing.T) {
 		want   string
 	}{
 		{"empty", fields{""}, "accept (quarantined)"},
-		{"simple", fields{"reason"}, "accept (quarantined: \"reason\")"},
-		{"EEC", fields{"2.6.0 I think this is spam"}, "2.6.0 I think this is spam"},
-		{"EEC err", fields{"4.6.0 I think this is spam"}, "accept (quarantined: \"4.6.0 I think this is spam\")"},
+		{"simple", fields{"reason"}, "accept (quarantined)"},
+		{"EEC", fields{"2.6.0 I think this is spam"}, "accept (quarantined)"},
+		{"EEC err", fields{"4.6.0 I think this is spam"}, "accept (quarantined)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/mailfilter/decision_test.go
+++ b/mailfilter/decision_test.go
@@ -5,53 +5,32 @@ import (
 	"testing"
 )
 
-func TestCustomErrorResponse(t *testing.T) {
+func Test_decision_Equal(t *testing.T) {
 	type args struct {
-		code   uint16
-		reason string
+		d2 Decision
 	}
 	tests := []struct {
 		name string
+		d    decision
 		args args
-		want Decision
+		want bool
 	}{
-		{"works", args{400, "test"}, &customResponse{400, "test"}},
+		{"works1", Accept, args{Accept}, true},
+		{"works2", Accept, args{Reject}, false},
+		{"acceptNil", Accept, args{nil}, false},
+		{"equalsCustom", Reject, args{CustomErrorResponse(550, "5.7.1 Command rejected")}, true},
+		{"equalsCustom1", TempFail, args{CustomErrorResponse(550, "5.7.1 Command rejected")}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CustomErrorResponse(tt.args.code, tt.args.reason); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CustomErrorResponse() = %v, want %v", got, tt.want)
+			if got := tt.d.Equal(tt.args.d2); got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func Test_customResponse_getCode(t *testing.T) {
-	type fields struct {
-		code   uint16
-		reason string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   uint16
-	}{
-		{"works", fields{400, "test"}, 400},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := customResponse{
-				code:   tt.fields.code,
-				reason: tt.fields.reason,
-			}
-			if got := c.getCode(); got != tt.want {
-				t.Errorf("getCode() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_customResponse_getReason(t *testing.T) {
+func Test_customResponse_String(t *testing.T) {
 	type fields struct {
 		code   uint16
 		reason string
@@ -61,7 +40,9 @@ func Test_customResponse_getReason(t *testing.T) {
 		fields fields
 		want   string
 	}{
-		{"works", fields{400, "test"}, "test"},
+		{"Empty", fields{400, ""}, "400 "},
+		{"Simple", fields{400, "Line 1"}, "400 Line 1"},
+		{"Multi", fields{400, "4.0.0 Line 1\nLine 2"}, "400-4.0.0 Line 1\r\n400 4.0.0 Line 2"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,42 +50,55 @@ func Test_customResponse_getReason(t *testing.T) {
 				code:   tt.fields.code,
 				reason: tt.fields.reason,
 			}
-			if got := c.getReason(); got != tt.want {
-				t.Errorf("getReason() = %v, want %v", got, tt.want)
+			if got := c.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
 			}
 		})
 	}
-}
-
-func Test_decision_getCode(t *testing.T) {
-	tests := []struct {
-		name string
-		d    decision
-		want uint16
-	}{
-		{"works", Accept, 250},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.d.getCode(); got != tt.want {
-				t.Errorf("getCode() = %v, want %v", got, tt.want)
+	t.Run("PanicOnWrongCode", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("String() did not panic")
 			}
-		})
-	}
+		}()
+		c := customResponse{99, ""}
+		if got := c.String(); got != "" {
+			t.Errorf("String() = %v, want %v", got, "")
+		}
+	})
+
 }
 
-func Test_decision_getReason(t *testing.T) {
+func Test_customResponse_Equal(t *testing.T) {
+	type fields struct {
+		code   uint16
+		reason string
+	}
+	type args struct {
+		d Decision
+	}
 	tests := []struct {
-		name string
-		d    decision
-		want string
+		name   string
+		fields fields
+		args   args
+		want   bool
 	}{
-		{"works", Accept, "accept"},
+		{"works1", fields{400, "test"}, args{&customResponse{400, "test"}}, true},
+		{"works2", fields{400, "test"}, args{&customResponse{400, "test1"}}, false},
+		{"works3", fields{400, "test"}, args{nil}, false},
+		{"default reject", fields{550, "5.7.1 Command rejected"}, args{Reject}, true},
+		{"default reject != temp fail", fields{550, "5.7.1 Command rejected"}, args{TempFail}, false},
+		{"default temp fail", fields{451, "4.7.1 Service unavailable - try again later"}, args{TempFail}, true},
+		{"default temp fail != reject", fields{451, "4.7.1 Service unavailable - try again later"}, args{Reject}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.d.getReason(); got != tt.want {
-				t.Errorf("getReason() = %v, want %v", got, tt.want)
+			c := customResponse{
+				code:   tt.fields.code,
+				reason: tt.fields.reason,
+			}
+			if got := c.Equal(tt.args.d); got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -127,38 +121,11 @@ func TestQuarantineResponse(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("QuarantineResponse() = %v, want %v", got, tt.want)
 			}
-			if got.getCode() != Accept.getCode() {
-				t.Errorf("QuarantineResponse().getCode() = %v, want %v", got.getCode(), Accept.getCode())
+			if got.String() != Accept.String() {
+				t.Errorf("QuarantineResponse().String() = %v, want %v", got.String(), Accept.String())
 			}
-			expectedReason := "accept (quarantined: \"reason\")"
-			if got.getReason() != expectedReason {
-				t.Errorf("QuarantineResponse().getReason() = %v, want %v", got.getReason(), expectedReason)
-			}
-		})
-	}
-}
-
-func Test_quarantineResponse_getReason(t *testing.T) {
-	type fields struct {
-		reason string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{"empty", fields{""}, "accept (quarantined)"},
-		{"simple", fields{"reason"}, "accept (quarantined)"},
-		{"EEC", fields{"2.6.0 I think this is spam"}, "accept (quarantined)"},
-		{"EEC err", fields{"4.6.0 I think this is spam"}, "accept (quarantined)"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := quarantineResponse{
-				reason: tt.fields.reason,
-			}
-			if got := c.getReason(); got != tt.want {
-				t.Errorf("getReason() = %v, want %v", got, tt.want)
+			if !got.Equal(Accept) {
+				t.Errorf("QuarantineResponse().Equal(Accept) = false, want true")
 			}
 		})
 	}

--- a/mailfilter/header/header.go
+++ b/mailfilter/header/header.go
@@ -29,11 +29,11 @@ type Header interface {
 	// When value is the empty string, the first header field with key gets deleted.
 	Set(key string, value string)
 	// SetText sets the value of the first header field with the canonical key "key" to "value" (encoded).
-	// If key was not found, this a new header field gets added.
+	// If key was not found, a new header field gets added.
 	SetText(key string, value string)
 	// SetAddressList sets the value of the first header field with the canonical key "key" to "value" (encoded as address list).
 	// The address list is encoded as multi-line header field when the MTA supports this (Sendmail does not).
-	// If key was not found, this a new header field gets added.
+	// If key was not found, a new header field gets added.
 	SetAddressList(key string, addresses []*mail.Address)
 	// Subject returns the decoded value of the Subject field.
 	// When decoding cannot be done (e.g. because the charset is not known) the decoding error will be returned.
@@ -52,6 +52,7 @@ type Header interface {
 	// When value is the zero [time.Time] value, the Date field gets deleted.
 	SetDate(value time.Time)
 	// Reader returns an [io.Reader] that produces a full properly encoded email header representation of the current fields of this header.
+	// The reader includes the final CR LF sequence that separates a mail header from the body.
 	Reader() io.Reader
 	// Fields returns a new scanner-like iterator that iterates through all fields of this header.
 	// If you modify the header fields while iterating over them (that is explicitly allowed) you should not use multiple

--- a/mailfilter/mailfilter.go
+++ b/mailfilter/mailfilter.go
@@ -3,6 +3,7 @@ package mailfilter
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 
@@ -24,14 +25,16 @@ import (
 type DecisionModificationFunc func(ctx context.Context, trx Trx) (decision Decision, err error)
 
 type MailFilter struct {
-	wgDone sync.WaitGroup
-	socket net.Listener
-	server *milter.Server
+	wgDone   sync.WaitGroup
+	socket   net.Listener
+	server   *milter.Server
+	options  options
+	protocol milter.OptProtocol
 }
 
 // New creates and starts a new [MailFilter] with a socket listening on network and address.
 // decision is the callback that should implement the filter logic.
-// opts are optional [Option] function that configure/fine-tune the mail filter.
+// opts are optional [Option] functions that configure/fine-tune the mail filter.
 func New(network, address string, decision DecisionModificationFunc, opts ...Option) (*MailFilter, error) {
 	resolvedOptions := options{
 		decisionAt:    DecisionAtEndOfMessage,
@@ -42,25 +45,64 @@ func New(network, address string, decision DecisionModificationFunc, opts ...Opt
 		o(&resolvedOptions)
 	}
 
+	if resolvedOptions.body == nil {
+		resolvedOptions.body = &bodyOption{
+			MaxMem:    200 * 1024,        // 200 KiB
+			MaxSize:   1024 * 1024 * 100, // 100 MiB
+			MaxAction: TruncateWhenTooBig,
+		}
+	} else {
+		if !resolvedOptions.body.Skip {
+			if resolvedOptions.body.MaxSize <= 0 {
+				return nil, fmt.Errorf("the parameter maxSize of WithBody must be positive")
+			}
+			if resolvedOptions.body.MaxAction != RejectMessageWhenTooBig && resolvedOptions.body.MaxAction != ClearWhenTooBig && resolvedOptions.body.MaxAction != TruncateWhenTooBig {
+				return nil, fmt.Errorf("the parameter maxAction of WithBody is invalid")
+			}
+			if resolvedOptions.body.MaxMem < 0 {
+				return nil, fmt.Errorf("the parameter maxMem of WithBody cannot be negative")
+			}
+		}
+	}
+	if resolvedOptions.header == nil {
+		resolvedOptions.header = &headerOption{
+			Max:       512,
+			MaxAction: TruncateWhenTooBig,
+		}
+	} else {
+		if resolvedOptions.header.Max == 0 {
+			return nil, fmt.Errorf("the parameter maxHeaders of WithHeader must be positive")
+		}
+		if resolvedOptions.header.MaxAction != RejectMessageWhenTooBig && resolvedOptions.header.MaxAction != ClearWhenTooBig && resolvedOptions.header.MaxAction != TruncateWhenTooBig {
+			return nil, fmt.Errorf("the parameter maxAction of WithHeader is invalid")
+		}
+	}
+	switch resolvedOptions.errorHandling {
+	case TempFailWhenError, RejectWhenError, AcceptWhenError, Error:
+		// nothing to do
+	default:
+		return nil, fmt.Errorf("the parameter errorHandling of WithErrorHandling is invalid")
+	}
+
 	actions := milter.AllClientSupportedActionMasks
-	protocols := milter.OptHeaderLeadingSpace | milter.OptNoUnknown
+	protocol := milter.OptHeaderLeadingSpace | milter.OptNoUnknown
 
 	switch resolvedOptions.decisionAt {
 	case DecisionAtConnect:
-		protocols = protocols | milter.OptNoHelo | milter.OptNoMailFrom | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
+		protocol = protocol | milter.OptNoHelo | milter.OptNoMailFrom | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
 	case DecisionAtHelo:
-		protocols = protocols | milter.OptNoConnReply | milter.OptNoMailFrom | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
+		protocol = protocol | milter.OptNoConnReply | milter.OptNoMailFrom | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
 	case DecisionAtMailFrom:
-		protocols = protocols | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
+		protocol = protocol | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
 	case DecisionAtData:
-		protocols = protocols | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptReply | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
+		protocol = protocol | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoMailReply | milter.OptNoRcptReply | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody
 	case DecisionAtEndOfHeaders:
-		protocols = protocols | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptReply | milter.OptNoHeaderReply | milter.OptNoBody
+		protocol = protocol | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoMailReply | milter.OptNoRcptReply | milter.OptNoDataReply | milter.OptNoHeaderReply | milter.OptNoBody
 	default:
-		protocols = protocols | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptReply | milter.OptNoHeaderReply | milter.OptNoEOHReply | milter.OptNoBodyReply
+		protocol = protocol | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptReply | milter.OptNoHeaderReply | milter.OptNoEOHReply | milter.OptNoBodyReply
 	}
-	if resolvedOptions.skipBody {
-		protocols = protocols | milter.OptNoBody
+	if resolvedOptions.body.Skip {
+		protocol = protocol | milter.OptNoBody
 	}
 	macroStages := make([][]milter.MacroName, 0, 6)
 	macroStages = append(macroStages, []milter.MacroName{milter.MacroIfName, milter.MacroIfAddr, milter.MacroMTAVersion, milter.MacroMTAFQDN, milter.MacroDaemonName}) // StageConnect
@@ -86,11 +128,11 @@ func New(network, address string, decision DecisionModificationFunc, opts ...Opt
 				opts:         resolvedOptions,
 				decision:     decision,
 				leadingSpace: protocol&milter.OptHeaderLeadingSpace != 0,
-				transaction:  &transaction{},
+				transaction:  &transaction{bodyOpt: *resolvedOptions.body},
 			}
 		}),
 		milter.WithActions(actions),
-		milter.WithProtocols(protocols),
+		milter.WithProtocols(protocol),
 	}
 	for i, macros := range macroStages {
 		milterOptions = append(milterOptions, milter.WithMacroRequest(milter.MacroStage(i), macros))
@@ -106,8 +148,10 @@ func New(network, address string, decision DecisionModificationFunc, opts ...Opt
 	server := milter.NewServer(milterOptions...)
 
 	f := &MailFilter{
-		socket: socket,
-		server: server,
+		socket:   socket,
+		server:   server,
+		options:  resolvedOptions,
+		protocol: protocol,
 	}
 
 	// start the milter
@@ -140,4 +184,9 @@ func (f *MailFilter) Wait() {
 // Close stops the [MailFilter] server.
 func (f *MailFilter) Close() {
 	_ = f.server.Close()
+}
+
+// Shutdown gracefully stops the [MailFilter] server.
+func (f *MailFilter) Shutdown(ctx context.Context) error {
+	return f.server.Shutdown(ctx)
 }

--- a/mailfilter/mailfilter_test.go
+++ b/mailfilter/mailfilter_test.go
@@ -1,0 +1,305 @@
+package mailfilter
+
+import (
+	"context"
+	"github.com/d--j/go-milter"
+	"math"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type testListener struct {
+	addr net.Addr
+}
+
+func (t testListener) Accept() (net.Conn, error) {
+	panic("implement me")
+}
+
+func (t testListener) Close() error {
+	panic("implement me")
+}
+
+func (t testListener) Addr() net.Addr {
+	return t.addr
+}
+
+func TestMailFilter_Addr(t *testing.T) {
+	testAddr := &net.TCPAddr{
+		IP:   net.IP([]byte{127, 0, 0, 1}),
+		Port: 1,
+	}
+	type fields struct {
+		socket net.Listener
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   net.Addr
+	}{
+		{"nil", fields{nil}, nil},
+		{"non-nil", fields{testListener{addr: testAddr}}, testAddr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &MailFilter{
+				socket: tt.fields.socket,
+			}
+			if got := f.Addr(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Addr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	decider := func(_ context.Context, _ Trx) (Decision, error) {
+		return Accept, nil
+	}
+	const endOfMessage = milter.OptHeaderLeadingSpace | milter.OptNoUnknown | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptReply | milter.OptNoHeaderReply | milter.OptNoEOHReply | milter.OptNoBodyReply
+	type args struct {
+		network  string
+		address  string
+		decision DecisionModificationFunc
+		opts     []Option
+	}
+	type want struct {
+		options  options
+		protocol milter.OptProtocol
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    want
+		wantErr bool
+	}{
+		{"err", args{}, want{options{}, 0}, true},
+		{"listen-err", args{"tcp", "bogus", decider, nil}, want{options{}, 0}, true},
+		{"defaults", args{"tcp", "127.0.0.1:", decider, nil}, want{
+			options{
+				decisionAt:    DecisionAtEndOfMessage,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			endOfMessage,
+		}, false},
+		{"decision-at-connect", args{"tcp", "127.0.0.1:", decider, []Option{WithDecisionAt(DecisionAtConnect)}}, want{
+			options{
+				decisionAt:    DecisionAtConnect,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			milter.OptHeaderLeadingSpace | milter.OptNoUnknown | milter.OptNoHelo | milter.OptNoMailFrom | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody,
+		}, false},
+		{"decision-at-helo", args{"tcp", "127.0.0.1:", decider, []Option{WithDecisionAt(DecisionAtHelo)}}, want{
+			options{
+				decisionAt:    DecisionAtHelo,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			milter.OptHeaderLeadingSpace | milter.OptNoUnknown | milter.OptNoConnReply | milter.OptNoMailFrom | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody,
+		}, false},
+		{"decision-at-mail-from", args{"tcp", "127.0.0.1:", decider, []Option{WithDecisionAt(DecisionAtMailFrom)}}, want{
+			options{
+				decisionAt:    DecisionAtMailFrom,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			milter.OptHeaderLeadingSpace | milter.OptNoUnknown | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoRcptTo | milter.OptNoData | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody,
+		}, false},
+		{"decision-at-data", args{"tcp", "127.0.0.1:", decider, []Option{WithDecisionAt(DecisionAtData)}}, want{
+			options{
+				decisionAt:    DecisionAtData,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			milter.OptHeaderLeadingSpace | milter.OptNoUnknown | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoMailReply | milter.OptNoRcptReply | milter.OptNoHeaders | milter.OptNoEOH | milter.OptNoBody,
+		}, false},
+		{"decision-at-eoh", args{"tcp", "127.0.0.1:", decider, []Option{WithDecisionAt(DecisionAtEndOfHeaders)}}, want{
+			options{
+				decisionAt:    DecisionAtEndOfHeaders,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			milter.OptHeaderLeadingSpace | milter.OptNoUnknown | milter.OptNoConnReply | milter.OptNoHeloReply | milter.OptNoMailReply | milter.OptNoRcptReply | milter.OptNoDataReply | milter.OptNoHeaderReply | milter.OptNoBody,
+		}, false},
+		{"without-body", args{"tcp", "127.0.0.1:", decider, []Option{WithoutBody()}}, want{
+			options{
+				decisionAt:    DecisionAtEndOfMessage,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip: true,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			endOfMessage | milter.OptNoBody,
+		}, false},
+		{"with-body", args{"tcp", "127.0.0.1:", decider, []Option{WithBody(12, 34, RejectMessageWhenTooBig)}}, want{
+			options{
+				decisionAt:    DecisionAtEndOfMessage,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    12,
+					MaxSize:   34,
+					MaxAction: RejectMessageWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			endOfMessage,
+		}, false},
+		{"with-body-err-1", args{"tcp", "127.0.0.1:", decider, []Option{WithBody(12, 34, 99)}}, want{}, true},
+		{"with-body-err-2", args{"tcp", "127.0.0.1:", decider, []Option{WithBody(12, 0, RejectMessageWhenTooBig)}}, want{}, true},
+		{"with-body-err-3", args{"tcp", "127.0.0.1:", decider, []Option{WithBody(-12, 34, RejectMessageWhenTooBig)}}, want{}, true},
+		{"with-header", args{"tcp", "127.0.0.1:", decider, []Option{WithHeader(1, RejectMessageWhenTooBig)}}, want{
+			options{
+				decisionAt:    DecisionAtEndOfMessage,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       1,
+					MaxAction: RejectMessageWhenTooBig,
+				},
+			},
+			endOfMessage,
+		}, false},
+		{"with-header-big", args{"tcp", "127.0.0.1:", decider, []Option{WithHeader(math.MaxUint32, TruncateWhenTooBig)}}, want{
+			options{
+				decisionAt:    DecisionAtEndOfMessage,
+				errorHandling: TempFailWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       math.MaxUint32,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			endOfMessage,
+		}, false},
+		{"with-header-err-1", args{"tcp", "127.0.0.1:", decider, []Option{WithHeader(0, RejectMessageWhenTooBig)}}, want{}, true},
+		{"with-header-err-2", args{"tcp", "127.0.0.1:", decider, []Option{WithHeader(1, 99)}}, want{}, true},
+		{"error-handling", args{"tcp", "127.0.0.1:", decider, []Option{WithErrorHandling(RejectWhenError)}}, want{
+			options{
+				decisionAt:    DecisionAtEndOfMessage,
+				errorHandling: RejectWhenError,
+				body: &bodyOption{
+					Skip:      false,
+					MaxMem:    1024 * 200,
+					MaxSize:   1024 * 1024 * 100,
+					MaxAction: TruncateWhenTooBig,
+				},
+				header: &headerOption{
+					Max:       512,
+					MaxAction: TruncateWhenTooBig,
+				},
+			},
+			endOfMessage,
+		}, false},
+		{"error-handling-err", args{"tcp", "127.0.0.1:", decider, []Option{WithErrorHandling(99)}}, want{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.args.network, tt.args.address, tt.args.decision, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == nil {
+					t.Fatal("New() is nil")
+				}
+				t.Cleanup(got.Close)
+				if !reflect.DeepEqual(got.options, tt.want.options) {
+					t.Errorf("New() resolvedOptions got = %+v, want %+v", got.options, tt.want.options)
+				}
+				if !reflect.DeepEqual(got.protocol, tt.want.protocol) {
+					t.Errorf("New() protocol got = \n%032b\nwant\n%032b", got.protocol, tt.want.protocol)
+				}
+				waited := make(chan struct{}, 1)
+				go func() {
+					got.Wait()
+					waited <- struct{}{}
+				}()
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+				defer cancel()
+				_ = got.Shutdown(shutdownCtx)
+				select {
+				case <-waited:
+				case <-time.After(5 * time.Second):
+					t.Fatalf("Wait() timeout")
+				}
+			}
+		})
+	}
+}

--- a/mailfilter/testtrx/example_test.go
+++ b/mailfilter/testtrx/example_test.go
@@ -3,7 +3,6 @@ package testtrx_test
 import (
 	"context"
 	"fmt"
-
 	"github.com/d--j/go-milter/mailfilter"
 	"github.com/d--j/go-milter/mailfilter/addr"
 	"github.com/d--j/go-milter/mailfilter/testtrx"
@@ -48,5 +47,5 @@ func ExampleTrx() {
 		fmt.Println(m)
 	}
 
-	// Output: {0  A=B 0   []}
+	// Output: ChangeFrom "" "A=B"
 }

--- a/mailfilter/testtrx/modification.go
+++ b/mailfilter/testtrx/modification.go
@@ -1,0 +1,117 @@
+package testtrx
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type ModificationKind int
+
+const (
+	ChangeFrom   ModificationKind = iota // a change mail from modification would have been sent to the MTA
+	AddRcptTo                            // an add-recipient modification would have been sent to the MTA
+	DelRcptTo                            // a delete-recipient modification would have been sent to the MTA
+	InsertHeader                         // an insert-header modification would have been sent to the MTA
+	ChangeHeader                         // a change-header modification would have been sent to the MTA
+	ReplaceBody                          // a replace-body modification would have been sent to the MTA
+)
+
+// Modification is a modification that a [mailfilter.DecisionModificationFunc] made to the Trx.
+type Modification struct {
+	Kind  ModificationKind
+	Addr  string
+	Args  string
+	Index int
+	Name  string
+	Value string
+	Body  []byte
+}
+
+func (m *Modification) String() string {
+	switch m.Kind {
+	case ChangeFrom:
+		return fmt.Sprintf("ChangeFrom %q %q", m.Addr, m.Args)
+	case AddRcptTo:
+		return fmt.Sprintf("AddRcptTo %q %q", m.Addr, m.Args)
+	case DelRcptTo:
+		return fmt.Sprintf("DelRcptTo %q", m.Addr)
+	case InsertHeader:
+		return fmt.Sprintf("InsertHeader %d %q %q", m.Index, m.Name, m.Value)
+	case ChangeHeader:
+		return fmt.Sprintf("ChangeHeader %d %q %q", m.Index, m.Name, m.Value)
+	case ReplaceBody:
+		bin := sha1.Sum(m.Body)
+		hash := hex.EncodeToString(bin[:])
+		return fmt.Sprintf("ReplaceBody len(body) = %d sha1(body) = %s", len(m.Body), hash)
+	}
+	return "Unknown modification"
+}
+
+// DiffModifications compares two slices of modifications and returns a human-readable string describing the differences.
+// It returns an empty string if the slices are equal.
+// If there are differences, the returned string will be formatted in unified diff format.
+// The diff algorithm is very naive so you will get unnecessarily big diffs.
+func DiffModifications(expected, got []Modification) string {
+	sortModifications(expected)
+	sortModifications(got)
+	expectedLen := len(expected)
+	gotLen := len(got)
+	// find common prefix
+	commonPrefixLen := 0
+	for i := 0; i < expectedLen && i < gotLen; i++ {
+		if expected[i].String() != got[i].String() {
+			break
+		}
+		commonPrefixLen += 1
+	}
+	// bail if the slices are equal
+	if commonPrefixLen == expectedLen && commonPrefixLen == gotLen {
+		return ""
+	}
+	// Output the diff
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("--- expected.txt\n+++ got.txt\n@@ -1,%d +1,%d @@\n", expectedLen, gotLen))
+	for i := range min(expectedLen, gotLen) {
+		e := expected[i].String()
+		g := got[i].String()
+		if e == g {
+			b.WriteString(" ")
+			b.WriteString(e)
+		} else {
+			b.WriteString("-")
+			b.WriteString(e)
+			b.WriteString("\n+")
+			b.WriteString(g)
+		}
+		b.WriteString("\n")
+	}
+	if expectedLen > gotLen {
+		for i := gotLen; i < expectedLen; i++ {
+			b.WriteString("-")
+			b.WriteString(expected[i].String())
+			b.WriteString("\n")
+		}
+	}
+	if gotLen > expectedLen {
+		for i := expectedLen; i < gotLen; i++ {
+			b.WriteString("+")
+			b.WriteString(got[i].String())
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+var sortOrder = map[ModificationKind]int{
+	ChangeFrom: -10, DelRcptTo: -9, AddRcptTo: -8, InsertHeader: -7, ChangeHeader: -7, ReplaceBody: -6,
+}
+
+// sortModifications sorts the modifications in the slice without changing the semantics.
+func sortModifications(mods []Modification) {
+	slices.SortStableFunc(mods, func(a, b Modification) int {
+		return sortOrder[a.Kind] - sortOrder[b.Kind]
+	})
+}

--- a/mailfilter/testtrx/modification_test.go
+++ b/mailfilter/testtrx/modification_test.go
@@ -1,0 +1,36 @@
+package testtrx
+
+import "testing"
+
+func TestDiffModifications(t *testing.T) {
+	delOne := Modification{Kind: DelRcptTo, Addr: "one@example.com"}
+	delTwo := Modification{Kind: DelRcptTo, Addr: "two@example.com"}
+	insertHeader := Modification{Kind: InsertHeader, Name: "X-Header-1", Value: "Value1"}
+	changeHeader := Modification{Kind: ChangeHeader, Name: "X-Header-2", Value: "Value2"}
+	replaceBody := Modification{Kind: ReplaceBody, Body: []byte("Body")}
+	type args struct {
+		expected []Modification
+		got      []Modification
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"Empty", args{[]Modification{}, []Modification{}}, ""},
+		{"Equal", args{[]Modification{insertHeader, delOne, changeHeader, replaceBody}, []Modification{replaceBody, insertHeader, delOne, changeHeader}}, ""},
+		{"DelRcptToOrderDoesNotMatter", args{[]Modification{delOne, delTwo}, []Modification{delTwo, delOne}}, ""},
+		{"Add", args{[]Modification{delOne}, []Modification{delTwo, delOne}}, "--- expected.txt\n+++ got.txt\n@@ -1,1 +1,2 @@\n DelRcptTo \"one@example.com\"\n+DelRcptTo \"two@example.com\"\n"},
+		{"Remove", args{[]Modification{delTwo, delOne}, []Modification{delOne}}, "--- expected.txt\n+++ got.txt\n@@ -1,2 +1,1 @@\n DelRcptTo \"one@example.com\"\n-DelRcptTo \"two@example.com\"\n"},
+		{"Remove2", args{[]Modification{insertHeader, delOne}, []Modification{delOne}}, "--- expected.txt\n+++ got.txt\n@@ -1,2 +1,1 @@\n DelRcptTo \"one@example.com\"\n-InsertHeader 0 \"X-Header-1\" \"Value1\"\n"},
+		{"NoPrefix", args{[]Modification{insertHeader}, []Modification{delOne}}, "--- expected.txt\n+++ got.txt\n@@ -1,1 +1,1 @@\n-InsertHeader 0 \"X-Header-1\" \"Value1\"\n+DelRcptTo \"one@example.com\"\n"},
+		{"MiddleDelete", args{[]Modification{delOne, delTwo, insertHeader}, []Modification{delOne, insertHeader}}, "--- expected.txt\n+++ got.txt\n@@ -1,3 +1,2 @@\n DelRcptTo \"one@example.com\"\n-DelRcptTo \"two@example.com\"\n+InsertHeader 0 \"X-Header-1\" \"Value1\"\n-InsertHeader 0 \"X-Header-1\" \"Value1\"\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DiffModifications(tt.args.expected, tt.args.got); got != tt.want {
+				t.Errorf("DiffModifications() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/mailfilter/testtrx/trx.go
+++ b/mailfilter/testtrx/trx.go
@@ -14,28 +14,6 @@ import (
 	"golang.org/x/text/transform"
 )
 
-type ModificationKind int
-
-const (
-	ChangeFrom   ModificationKind = iota // a change mail from modification would have been sent to the MTA
-	AddRcptTo                            // an add-recipient modification would have been sent to the MTA
-	DelRcptTo                            // a delete-recipient modification would have been sent to the MTA
-	InsertHeader                         // an insert-header modification would have been sent to the MTA
-	ChangeHeader                         // a change-header modification would have been sent to the MTA
-	ReplaceBody                          // a replace-body modification would have been sent to the MTA
-)
-
-// Modification is a modification that a [mailfilter.DecisionModificationFunc] made to the Trx.
-type Modification struct {
-	Kind  ModificationKind
-	Addr  string
-	Args  string
-	Index int
-	Name  string
-	Value string
-	Body  []byte
-}
-
 // Trx implements [mailfilter.Trx] for unit tests.
 // Use this struct when you want to test your decision functions.
 // You can use the fluent Set* methods of this struct to build up the transaction you want to test.

--- a/mailfilter/testtrx/trx.go
+++ b/mailfilter/testtrx/trx.go
@@ -3,8 +3,7 @@ package testtrx
 
 import (
 	"bytes"
-	"io"
-
+	"github.com/d--j/go-milter/internal/body"
 	"github.com/d--j/go-milter/internal/header"
 	"github.com/d--j/go-milter/internal/rcptto"
 	"github.com/d--j/go-milter/mailfilter"
@@ -12,6 +11,7 @@ import (
 	header2 "github.com/d--j/go-milter/mailfilter/header"
 	"github.com/d--j/go-milter/milterutil"
 	"golang.org/x/text/transform"
+	"io"
 )
 
 // Trx implements [mailfilter.Trx] for unit tests.
@@ -33,6 +33,11 @@ type Trx struct {
 	enforceHeaderOrder bool
 	body               io.ReadSeeker
 	bodyReplacement    io.Reader
+	replacementBuffer  *body.Body
+	// MaxMem can be used to set the maximum memory used for the body replacement buffer.
+	// If MaxMem is nil, the default value of 200KiB is used.
+	// If the body replacement buffer exceeds this limit, the replacement buffer will automatically be buffered to disk.
+	MaxMem *int
 }
 
 func (t *Trx) MTA() *mailfilter.MTA {
@@ -161,6 +166,33 @@ func (t *Trx) ReplaceBody(r io.Reader) {
 	t.bodyReplacement = r
 }
 
+func (t *Trx) Data() io.Reader {
+	if t.bodyReplacement != nil && t.replacementBuffer == nil {
+		maxMem := 200 * 1024
+		if t.MaxMem != nil {
+			maxMem = *t.MaxMem
+		}
+		t.replacementBuffer = body.New(maxMem, 0)
+		_, err := io.Copy(t.replacementBuffer, t.bodyReplacement)
+		if err != nil {
+			t.replacementBuffer = nil
+			return io.MultiReader(t.Headers().Reader(), body.ErrReader{Err: err})
+		}
+	}
+	if t.replacementBuffer != nil {
+		_, err := t.replacementBuffer.Seek(0, io.SeekStart)
+		if err != nil {
+			return io.MultiReader(t.Headers().Reader(), body.ErrReader{Err: err})
+		}
+		return io.MultiReader(t.Headers().Reader(), t.replacementBuffer)
+	}
+	b := t.Body()
+	if b != nil {
+		return io.MultiReader(t.Headers().Reader(), b)
+	}
+	return t.Headers().Reader()
+}
+
 func (t *Trx) QueueId() string {
 	return t.queueId
 }
@@ -196,7 +228,17 @@ func (t *Trx) Modifications() []Modification {
 		mods = append(mods, Modification{Kind: InsertHeader, Index: op.Index + len(changeInsertOps) + 100, Name: op.Name, Value: op.Value})
 	}
 
-	if t.bodyReplacement != nil {
+	if t.replacementBuffer != nil {
+		_, err := t.replacementBuffer.Seek(0, io.SeekStart)
+		if err != nil {
+			panic(err)
+		}
+		b, err := io.ReadAll(t.replacementBuffer)
+		if err != nil {
+			panic(err)
+		}
+		mods = append(mods, Modification{Kind: ReplaceBody, Body: b})
+	} else if t.bodyReplacement != nil {
 		b, err := io.ReadAll(t.bodyReplacement)
 		if err != nil {
 			panic(err)

--- a/mailfilter/testtrx/trx_test.go
+++ b/mailfilter/testtrx/trx_test.go
@@ -2,6 +2,8 @@ package testtrx
 
 import (
 	"bytes"
+	"github.com/d--j/go-milter/internal/body"
+	"io"
 	"reflect"
 	"testing"
 
@@ -41,6 +43,15 @@ func TestTestTrx(t *testing.T) {
 		SetHeaders(hdr).
 		SetBodyBytes([]byte("test body"))
 
+	if trx.MTA() == nil || trx.MTA().FQDN != "mx.example.net" {
+		t.Errorf("MTA.FQDN expected to be mx.example.net, got %v", trx.MTA().FQDN)
+	}
+	if trx.Connect() == nil || trx.Connect().Addr != "127.0.0.1" {
+		t.Errorf("Connect.Addr expected to be 127.0.0.1, got %v", trx.Connect().Addr)
+	}
+	if trx.Helo() == nil || trx.Helo().Name != "localhost" {
+		t.Errorf("Helo.Name expected to be localhost, got %v", trx.Helo().Name)
+	}
 	if trx.MailFrom() == nil || trx.MailFrom().Addr != "root@localhost" {
 		t.Errorf("MailFrom expected to be root@localhost, got %v", trx.MailFrom())
 	}
@@ -84,7 +95,106 @@ func TestTestTrx(t *testing.T) {
 		{Kind: InsertHeader, Index: 104, Name: "X-Add", Value: " 1"},
 		{Kind: ReplaceBody, Body: []byte("new body")},
 	}
-	if !reflect.DeepEqual(m, expected) {
-		t.Fatalf("trx.Modifications() = %+v, want %+v", m, expected)
+	if diff := DiffModifications(expected, m); diff != "" {
+		t.Fatalf("trxSendmail.Modifications() diff\n%s", diff)
+	}
+
+	trxSendmail := (&Trx{}).SetMTA(mailfilter.MTA{
+		Version: "8.0.0",
+		FQDN:    "mx.example.net",
+		Daemon:  "smtpd",
+	}).SetHeadersRaw([]byte("Subject: test\nX-H: 1\n\n"))
+	trxSendmail.HeadersEnforceOrder()
+	if trxSendmail.enforceHeaderOrder != true {
+		t.Fatalf("HeadersEnforceOrder expected set the flag")
+	}
+	trxSendmail.Headers().Add("X-Add", "1")
+	m = trxSendmail.Modifications()
+	expected = []Modification{
+		{Kind: ChangeHeader, Index: 1, Name: "X-H", Value: ""},
+		{Kind: ChangeHeader, Index: 1, Name: "Subject", Value: ""},
+		{Kind: InsertHeader, Index: 102, Name: "Subject", Value: " test"},
+		{Kind: InsertHeader, Index: 103, Name: "X-H", Value: " 1"},
+		{Kind: InsertHeader, Index: 104, Name: "X-Add", Value: " 1"},
+	}
+	if diff := DiffModifications(expected, m); diff != "" {
+		t.Fatalf("trxSendmail.Modifications() diff\n%s", diff)
+	}
+}
+
+func TestTrx_Data(t *testing.T) {
+	const headers = "Subject: test\r\nX-H: 1\r\n\r\n"
+	var two = 2
+	type fields struct {
+		changeHeader    bool
+		body            []byte
+		bodyReplacement []byte
+		maxMem          *int
+		callData        bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []byte
+	}{
+		{"no-replace-no-body", fields{false, nil, nil, nil, true}, []byte{}},
+		{"no-replace-body", fields{false, []byte("test"), nil, nil, true}, []byte("test")},
+		{"replace-no-body", fields{false, nil, []byte("test"), nil, true}, []byte("test")},
+		{"replace-and-body", fields{false, []byte("test"), []byte("test1"), nil, true}, []byte("test1")},
+		{"replace-no-body-wo-data", fields{false, nil, []byte("test"), nil, false}, []byte("test")},
+		{"replace-and-body-wo-data", fields{false, []byte("test"), []byte("test1"), nil, false}, []byte("test1")},
+		{"change-header", fields{true, []byte("test"), []byte("test1"), nil, true}, []byte("test1")},
+		{"use-temp-file", fields{true, []byte("test"), []byte("test1"), &two, true}, []byte("test1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdr, _ := header.New([]byte(headers))
+			trx := &Trx{
+				origHeader: hdr,
+				MaxMem:     tt.fields.maxMem,
+			}
+			trx.header = trx.origHeader.Copy()
+			if tt.fields.changeHeader {
+				trx.header.Set("X-Change", "1")
+			}
+			if tt.fields.body != nil {
+				b := body.New(len(tt.fields.body), int64(len(tt.fields.body)))
+				_, _ = b.Write(tt.fields.body)
+				trx.body = b
+			}
+			if tt.fields.bodyReplacement != nil {
+				trx.bodyReplacement = bytes.NewReader(tt.fields.bodyReplacement)
+			}
+			r := trx.Data()
+			if r == nil {
+				t.Fatal("Data() returned nil")
+			}
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("Data() returned error: %v", err)
+			}
+			want, _ := io.ReadAll(trx.Headers().Reader())
+			want = append(want, tt.want...)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("Data() = %q, want %q", got, want)
+			}
+			if tt.fields.bodyReplacement != nil {
+				m := trx.Modifications()
+				// filter out all modifications except ReplaceBody since that's the only one we care about here
+				filteredM := make([]Modification, 0, len(m))
+				for _, mod := range m {
+					if mod.Kind != ReplaceBody {
+						continue
+					}
+					filteredM = append(filteredM, mod)
+				}
+				expected := []Modification{
+					{Kind: ReplaceBody, Body: tt.fields.bodyReplacement},
+				}
+				if diff := DiffModifications(expected, filteredM); diff != "" {
+					t.Fatalf("trx.Modifications() diff\n%s", diff)
+				}
+			}
+		})
 	}
 }

--- a/mailfilter/transaction.go
+++ b/mailfilter/transaction.go
@@ -161,6 +161,10 @@ func (t *transaction) hasModifications() bool {
 	if !t.hasDecision {
 		return false
 	}
+	// if we reject the message, we do not need to check for modifications
+	if t.decision != Accept {
+		return false
+	}
 	if t.quarantineReason != nil {
 		return true
 	}
@@ -192,6 +196,11 @@ func (t *transaction) hasModifications() bool {
 }
 
 func (t *transaction) sendModifications(m *milter.Modifier) error {
+	// if we reject the message, we do not need to send modifications
+	// they are useless since we do not keep the message anyway
+	if t.decision != Accept {
+		return nil
+	}
 	if t.origMailFrom.Addr != t.mailFrom.Addr || t.origMailFrom.Args != t.mailFrom.Args {
 		if err := m.ChangeFrom(t.mailFrom.Addr, t.mailFrom.Args); err != nil {
 			return err

--- a/milterutil/response.go
+++ b/milterutil/response.go
@@ -1,0 +1,46 @@
+package milterutil
+
+import (
+	"fmt"
+	"golang.org/x/text/transform"
+	"strings"
+)
+
+// MaxResponseSize is the maximum size of a response string in bytes.
+// It is 64 KiB - 2 bytes.
+// It is unknown if all MTA implementations can handle such long responses.
+// But it is the technical maximum size of a response string (One milter packet is 64KB minus 1 byte for the null-byte and 1 byte for the command byte).
+const MaxResponseSize = 64*1024*1024 - 2
+
+// FormatResponse generates an SMTP response string.
+// smtpCode must be between 100 and 599, otherwise this function returns an error.
+// reason is the human-readable reason for the response (UTF-8 encoded). It can start with an RFC 2034 Enhanced Error Code.
+// The response is formatted as a multi-line response when (a) the reason already contains new-lines, or (b) the lines would get longer than 950 bytes.
+// "\n" line endings in reason get canonicalized to "\r\n". "%" in reason get replaced with "%%".
+// This function returns an error when the resulting SMTP text has a length of more than [DataSize64K] - 1 (65534 bytes).
+//
+// Some examples:
+//
+//	FormatResponse(250, "Accept") // "250 Accept"
+//	FormatResponse(250, "%") // "250 %%"
+//	FormatResponse(550, "5.7.1 Command rejected") // "550 5.7.1 Command rejected"
+//	FormatResponse(550, "5.7.1 Command rejected\nContact support") // "550-5.7.1 Command rejected\r\n550 5.7.1 Contact support"
+//
+// See https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml for a list of extended error codes and when to use them.
+func FormatResponse(smtpCode uint16, reason string) (string, error) {
+	if smtpCode < 100 || smtpCode > 599 {
+		return "", fmt.Errorf("milter: invalid code %d", smtpCode)
+	}
+	// bail early if the reason is way too long
+	if len(reason) > MaxResponseSize-4 {
+		return "", fmt.Errorf("milter: reason too long: %d > %d", len(reason), MaxResponseSize-4)
+	}
+	escapeAndNormalize := transform.Chain(&DoublePercentTransformer{}, &CrLfCanonicalizationTransformer{})
+	data, _, _ := transform.String(escapeAndNormalize, strings.TrimRight(reason, "\r\n"))
+	data, _, _ = transform.String(&MaximumLineLengthTransformer{}, data)
+	data, _, _ = transform.String(&SMTPReplyTransformer{Code: smtpCode}, data)
+	if len(data) > MaxResponseSize {
+		return "", fmt.Errorf("milter: formatted reason too long: %d > %d", len(data), MaxResponseSize)
+	}
+	return data, nil
+}

--- a/milterutil/response.go
+++ b/milterutil/response.go
@@ -9,14 +9,14 @@ import (
 // MaxResponseSize is the maximum size of a response string in bytes.
 // It is 64 KiB - 2 bytes.
 // It is unknown if all MTA implementations can handle such long responses.
-// But it is the technical maximum size of a response string (One milter packet is 64KB minus 1 byte for the null-byte and 1 byte for the command byte).
+// But it is the technical maximum size of a response string (One milter packet is 64KB minus 1 byte for the NUL byte and 1 byte for the command byte).
 const MaxResponseSize = 64*1024*1024 - 2
 
 // FormatResponse generates an SMTP response string.
 // smtpCode must be between 100 and 599, otherwise this function returns an error.
 // reason is the human-readable reason for the response (UTF-8 encoded). It can start with an RFC 2034 Enhanced Error Code.
 // The response is formatted as a multi-line response when (a) the reason already contains new-lines, or (b) the lines would get longer than 950 bytes.
-// "\n" line endings in reason get canonicalized to "\r\n". "%" in reason get replaced with "%%".
+// "\n" line endings in reason get canonicalized to "\r\n". NUL bytes get with SP. "%" in reason get replaced with "%%".
 // This function returns an error when the resulting SMTP text has a length of more than [DataSize64K] - 1 (65534 bytes).
 //
 // Some examples:
@@ -25,6 +25,7 @@ const MaxResponseSize = 64*1024*1024 - 2
 //	FormatResponse(250, "%") // "250 %%"
 //	FormatResponse(550, "5.7.1 Command rejected") // "550 5.7.1 Command rejected"
 //	FormatResponse(550, "5.7.1 Command rejected\nContact support") // "550-5.7.1 Command rejected\r\n550 5.7.1 Contact support"
+//	FormatResponse(550, "Crazy\u0000") // "550 Crazy "
 //
 // See https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml for a list of extended error codes and when to use them.
 func FormatResponse(smtpCode uint16, reason string) (string, error) {
@@ -35,7 +36,7 @@ func FormatResponse(smtpCode uint16, reason string) (string, error) {
 	if len(reason) > MaxResponseSize-4 {
 		return "", fmt.Errorf("milter: reason too long: %d > %d", len(reason), MaxResponseSize-4)
 	}
-	escapeAndNormalize := transform.Chain(&DoublePercentTransformer{}, &CrLfCanonicalizationTransformer{})
+	escapeAndNormalize := transform.Chain(&NulToSpTransformer{}, &DoublePercentTransformer{}, &CrLfCanonicalizationTransformer{})
 	data, _, _ := transform.String(escapeAndNormalize, strings.TrimRight(reason, "\r\n"))
 	data, _, _ = transform.String(&MaximumLineLengthTransformer{}, data)
 	data, _, _ = transform.String(&SMTPReplyTransformer{Code: smtpCode}, data)

--- a/milterutil/response_test.go
+++ b/milterutil/response_test.go
@@ -18,6 +18,7 @@ func TestFormatResponse(t *testing.T) {
 	}{
 		{"EmptyReason", args{400, ""}, "400 ", false},
 		{"SimpleReason", args{400, "Test 1"}, "400 Test 1", false},
+		{"FixedReason", args{400, "Test 1\u0000"}, "400 Test 1 ", false},
 		{"TrimmedReason1", args{400, "\n\n\n"}, "400 ", false},
 		{"TrimmedReason2", args{400, "Line 1\r\n"}, "400 Line 1", false},
 		{"Multiline1", args{400, "Line 1\nLine 2"}, "400-Line 1\r\n400 Line 2", false},

--- a/milterutil/response_test.go
+++ b/milterutil/response_test.go
@@ -1,0 +1,45 @@
+package milterutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatResponse(t *testing.T) {
+	type args struct {
+		smtpCode uint16
+		reason   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"EmptyReason", args{400, ""}, "400 ", false},
+		{"SimpleReason", args{400, "Test 1"}, "400 Test 1", false},
+		{"TrimmedReason1", args{400, "\n\n\n"}, "400 ", false},
+		{"TrimmedReason2", args{400, "Line 1\r\n"}, "400 Line 1", false},
+		{"Multiline1", args{400, "Line 1\nLine 2"}, "400-Line 1\r\n400 Line 2", false},
+		{"Multiline2", args{400, "Line 1\r\nLine 2"}, "400-Line 1\r\n400 Line 2", false},
+		{"Multiline3", args{400, "4.0.0 Line 1\nLine 2"}, "400-4.0.0 Line 1\r\n400 4.0.0 Line 2", false},
+		{"Multiline4", args{400, "5.0.0 Line 1\nLine 2"}, "400-5.0.0 Line 1\r\n400 Line 2", false},
+		{"Multiline5", args{400, "\nLine 1\nLine 2"}, "400-\r\n400-Line 1\r\n400 Line 2", false},
+		{"WrongCode1", args{99, ""}, "", true},
+		{"WrongCode2", args{600, ""}, "", true},
+		{"TooBigIn", args{250, strings.Repeat(" ", 64*1024*1024)}, "", true},
+		{"TooBigOut", args{250, strings.Repeat("1\n", (64*1024*1024)/2-10)}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FormatResponse(tt.args.smtpCode, tt.args.reason)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FormatResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("FormatResponse() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/milterutil/transformer_test.go
+++ b/milterutil/transformer_test.go
@@ -267,24 +267,6 @@ func TestMaximumLineLengthTransformer(t *testing.T) {
 	})
 }
 
-func TestCrLfToLf(t *testing.T) {
-	tests := []struct {
-		name string
-		arg  string
-		want string
-	}{
-		{"empty", "", ""},
-		{"simple", "\r\n", "\n"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := CrLfToLf(tt.arg); got != tt.want {
-				t.Errorf("CrLfToLf() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func FuzzCrLfToLfTransformer_Transform(f *testing.F) {
 	f.Add([]byte("\r\n"), []byte(""), true)
 	f.Add([]byte("\r"), []byte("\n"), true)
@@ -538,4 +520,81 @@ func FuzzSMTPReplyTransformer_Transform(f *testing.F) {
 			t.Fatalf("not valid SMTP response: %q", output)
 		}
 	})
+}
+
+func TestNewlineToSpaceTransformer(t *testing.T) {
+	// transform.Transformer uses initial dst buffer size of 4096 bytes
+	stuffing := strings.Repeat("1234567890", 4090/10)
+	t.Parallel()
+	doTransformerTest(t, func() transform.Transformer {
+		return &NewlineToSpaceTransformer{}
+	}, nil, transformerTestCases{
+		{[]string{""}, ""},
+		{[]string{"\n"}, " "},
+		{[]string{"\r"}, " "},
+		{[]string{"\r\n"}, " "},
+		{[]string{"\r\r\n"}, "  "},
+		{[]string{"\r\n\r"}, "  "},
+		{[]string{"\r\n\r\n"}, "  "},
+		{[]string{"line1\r\nline2\r\n"}, "line1 line2 "},
+		{[]string{"\r", "\n"}, " "},
+		{[]string{"\r\r", "\n"}, "  "},
+		{[]string{stuffing + "123456\r", "\n"}, stuffing + "123456 "},
+		{[]string{"aaaaaaaaaaaaaaaaaaaaaaaa\r\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\nbbbbbbb"}, "aaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbb"},
+	})
+}
+
+func TestNulToSpaceTransformer(t *testing.T) {
+	// transform.Transformer uses initial dst buffer size of 4096 bytes
+	stuffing := strings.Repeat("1234567890", 4090/10)
+	t.Parallel()
+	doTransformerTest(t, func() transform.Transformer {
+		return &NulToSpTransformer{}
+	}, nil, transformerTestCases{
+		{[]string{""}, ""},
+		{[]string{"\u0000"}, " "},
+		{[]string{"\u0000\u0000"}, "  "},
+		{[]string{"\u0000", "\u0000"}, "  "},
+		{[]string{stuffing + "123456\u0000", "\u0000"}, stuffing + "123456  "},
+	})
+}
+
+func TestCrLfToLf(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"simple", "\r\n", "\n"},
+		{"with-zero", "\r\n\u0000", "\n "},
+		{"with-zero2", "\u0000\r\n\u0000", " \n "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CrLfToLf(tt.arg); got != tt.want {
+				t.Errorf("CrLfToLf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewlineToSpace(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"simple", "\r\n", " "},
+		{"with-zero", "\r\n\u0000", "  "},
+		{"with-zero2", "\u0000\r\n\u0000", "   "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewlineToSpace(tt.arg); got != tt.want {
+				t.Errorf("NewlineToSpace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/milterutil/transformer_test.go
+++ b/milterutil/transformer_test.go
@@ -3,6 +3,7 @@ package milterutil
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/textproto"
@@ -249,7 +250,7 @@ func TestMaximumLineLengthTransformer(t *testing.T) {
 	t.Run("enforce minimum", func(t *testing.T) {
 		t.Parallel()
 		_, err := doTransformation(&MaximumLineLengthTransformer{MaximumLength: 1}, []string{""})
-		if err != errWrongMaximumLineLength {
+		if !errors.Is(err, errWrongMaximumLineLength) {
 			t.Fatalf("err got %s, expected %s", err, errWrongMaximumLineLength)
 		}
 	})

--- a/modifier_test.go
+++ b/modifier_test.go
@@ -1,0 +1,712 @@
+package milter
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"github.com/d--j/go-milter/internal/wire"
+	"io"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestAction_StopProcessing(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionType ActionType
+		want       bool
+	}{
+		{"empty", ActionType(0), false},
+		{"ActionAccept", ActionAccept, false},
+		{"ActionContinue", ActionContinue, false},
+		{"ActionDiscard", ActionDiscard, false},
+		{"ActionReject", ActionReject, true},
+		{"ActionTempFail", ActionTempFail, true},
+		{"ActionSkip", ActionSkip, false},
+		{"ActionRejectWithCode", ActionRejectWithCode, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Action{
+				Type: tt.actionType,
+			}
+			if got := a.StopProcessing(); got != tt.want {
+				t.Errorf("StopProcessing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     *wire.Message
+		want    *Action
+		wantErr bool
+	}{
+		{"accept", &wire.Message{Code: wire.Code(wire.ActAccept)}, &Action{Type: ActionAccept, SMTPCode: 250, SMTPReply: "250 accept"}, false},
+		{"continue", &wire.Message{Code: wire.Code(wire.ActContinue)}, &Action{Type: ActionContinue, SMTPCode: 250, SMTPReply: "250 accept"}, false},
+		{"discard", &wire.Message{Code: wire.Code(wire.ActDiscard)}, &Action{Type: ActionDiscard, SMTPCode: 250, SMTPReply: "250 accept"}, false},
+		{"reject", &wire.Message{Code: wire.Code(wire.ActReject)}, &Action{Type: ActionReject, SMTPCode: 550, SMTPReply: "550 5.7.1 Command rejected"}, false},
+		{"temp-fail", &wire.Message{Code: wire.Code(wire.ActTempFail)}, &Action{Type: ActionTempFail, SMTPCode: 451, SMTPReply: "451 4.7.1 Service unavailable - try again later"}, false},
+		{"skip", &wire.Message{Code: wire.Code(wire.ActSkip)}, &Action{Type: ActionSkip, SMTPCode: 250, SMTPReply: "250 accept"}, false},
+		{"repl-code", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("550 5.7.1 Reject\u0000")}, &Action{Type: ActionRejectWithCode, SMTPCode: 550, SMTPReply: "550 5.7.1 Reject"}, false},
+		{"repl-code-trim", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("550 5.7.1 Reject\r\n\u0000")}, &Action{Type: ActionRejectWithCode, SMTPCode: 550, SMTPReply: "550 5.7.1 Reject"}, false},
+		{"repl-code-double-nul", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("550 5.7.1 Reject\u0000stuff\u0000")}, &Action{Type: ActionRejectWithCode, SMTPCode: 550, SMTPReply: "550 5.7.1 Reject"}, false},
+		{"repl-code-multiline", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("550-5.7.1 Reject\r\n550-5.7.1 this\r\n550 5.7.1 message\u0000")}, &Action{Type: ActionRejectWithCode, SMTPCode: 550, SMTPReply: "550-5.7.1 Reject\r\n550-5.7.1 this\r\n550 5.7.1 message"}, false},
+		{"repl-code-multiline-trim", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("550-5.7.1 Reject\r\n550-5.7.1 this\r\n550 5.7.1 message\r\n\u0000")}, &Action{Type: ActionRejectWithCode, SMTPCode: 550, SMTPReply: "550-5.7.1 Reject\r\n550-5.7.1 this\r\n550 5.7.1 message"}, false},
+		{"repl-code-err", &wire.Message{Code: wire.Code(wire.ActReplyCode)}, nil, true},
+		{"repl-code-err-wo-nul", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("550 5.7.1 Reject")}, nil, true},
+		{"repl-code-err-invalid-code", &wire.Message{Code: wire.Code(wire.ActReplyCode), Data: []byte("250 Accept\u0000")}, nil, true},
+		{"unknown", &wire.Message{Code: wire.Code('?'), Data: []byte("550 Reject\u0000")}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAction(tt.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAction() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAction() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseModifyAct(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     *wire.Message
+		want    *ModifyAction
+		wantErr bool
+	}{
+		{"ActionAddRcpt", &wire.Message{Code: wire.Code(wire.ActAddRcpt), Data: []byte("<>\u0000")}, &ModifyAction{Type: ActionAddRcpt, Rcpt: "<>"}, false},
+		{"ActionAddRcpt-err1", &wire.Message{Code: wire.Code(wire.ActAddRcpt), Data: []byte("<>\u0000\u0000")}, nil, true},
+		{"ActionAddRcpt-err2", &wire.Message{Code: wire.Code(wire.ActAddRcpt), Data: []byte("<>")}, nil, true},
+		{"ActAddRcptPar1", &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>\u0000")}, &ModifyAction{Type: ActionAddRcpt, Rcpt: "<>"}, false},
+		{"ActAddRcptPar2", &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>\u0000A=B\u0000")}, &ModifyAction{Type: ActionAddRcpt, Rcpt: "<>", RcptArgs: "A=B"}, false},
+		{"ActAddRcptPar-err1", &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>\u0000\u0000\u0000")}, nil, true},
+		{"ActAddRcptPar-err2", &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>")}, nil, true},
+		{"ActChangeFrom1", &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000")}, &ModifyAction{Type: ActionChangeFrom, From: "<>"}, false},
+		{"ActChangeFrom2", &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000A=B\u0000")}, &ModifyAction{Type: ActionChangeFrom, From: "<>", FromArgs: "A=B"}, false},
+		{"ActChangeFrom-err1", &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000\u0000\u0000")}, nil, true},
+		{"ActChangeFrom-err2", &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>")}, nil, true},
+		{"ActDelRcpt", &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("<>\u0000")}, &ModifyAction{Type: ActionDelRcpt, Rcpt: "<>"}, false},
+		{"ActDelRcpt-double-nul", &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("<>\u0000stuff\u0000")}, &ModifyAction{Type: ActionDelRcpt, Rcpt: "<>"}, false},
+		{"ActDelRcpt-err", &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("<>")}, nil, true},
+		{"ActQuarantine", &wire.Message{Code: wire.Code(wire.ActQuarantine), Data: []byte("reason\u0000")}, &ModifyAction{Type: ActionQuarantine, Reason: "reason"}, false},
+		{"ActQuarantine-double-nul", &wire.Message{Code: wire.Code(wire.ActQuarantine), Data: []byte("reason\u0000stuff\u0000")}, &ModifyAction{Type: ActionQuarantine, Reason: "reason"}, false},
+		{"ActQuarantine-err", &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("reason")}, nil, true},
+		{"ActReplBody", &wire.Message{Code: wire.Code(wire.ActReplBody), Data: []byte("data")}, &ModifyAction{Type: ActionReplaceBody, Body: []byte("data")}, false},
+		{"ActChangeHeader", &wire.Message{Code: wire.Code(wire.ActChangeHeader), Data: []byte{0, 0, 0, 1, 'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e', 0}}, &ModifyAction{Type: ActionChangeHeader, HeaderIndex: 1, HeaderName: "Subject", HeaderValue: "value"}, false},
+		{"ActChangeHeader-sendmail", &wire.Message{Code: wire.Code(wire.ActChangeHeader), Data: []byte{0, 0, 0, 0, 'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e', 0}}, &ModifyAction{Type: ActionChangeHeader, HeaderIndex: 1, HeaderName: "Subject", HeaderValue: "value"}, false},
+		{"ActInsertHeader", &wire.Message{Code: wire.Code(wire.ActInsertHeader), Data: []byte{0, 0, 0, 1, 'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e', 0}}, &ModifyAction{Type: ActionInsertHeader, HeaderIndex: 1, HeaderName: "Subject", HeaderValue: "value"}, false},
+		{"ActAddHeader", &wire.Message{Code: wire.Code(wire.ActAddHeader), Data: []byte{'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e', 0}}, &ModifyAction{Type: ActionAddHeader, HeaderName: "Subject", HeaderValue: "value"}, false},
+		{"ActChangeHeader-err", &wire.Message{Code: wire.Code(wire.ActChangeHeader), Data: []byte{0, 0, 0, 1, 'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e'}}, nil, true},
+		{"ActInsertHeader-err", &wire.Message{Code: wire.Code(wire.ActInsertHeader), Data: []byte{0, 0, 0, 1, 'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e'}}, nil, true},
+		{"ActAddHeader-err", &wire.Message{Code: wire.Code(wire.ActInsertHeader), Data: []byte{'S', 'u', 'b', 'j', 'e', 'c', 't', 0, 'v', 'a', 'l', 'u', 'e'}}, nil, true},
+		{"unknown", &wire.Message{Code: wire.Code('?'), Data: []byte("\u0000")}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseModifyAct(tt.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseModifyAct() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseModifyAct() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddAngle(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"empty", "", "<>"},
+		{"no angle", "test", "<test>"},
+		{"with angle", "<test>", "<test>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddAngle(tt.arg); got != tt.want {
+				t.Errorf("AddAngle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveAngle(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no angle", "test", "test"},
+		{"with angle", "<test>", "test"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveAngle(tt.arg); got != tt.want {
+				t.Errorf("RemoveAngle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_AddHeader(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		name  string
+		value string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{"Subject", "Test"}, &wire.Message{Code: wire.Code(wire.ActAddHeader), Data: []byte("Subject\000Test\000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{"Subject", "Test"}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{"Subject", "Test"}, nil, true},
+		{"invalid-name-1", fields{false, AllClientSupportedActionMasks}, args{"Subject:", "Test"}, nil, true},
+		{"invalid-name-2", fields{false, AllClientSupportedActionMasks}, args{" Subject", "Test"}, nil, true},
+		{"invalid-name-3", fields{false, AllClientSupportedActionMasks}, args{"Subj\u0000ect", "Test"}, nil, true},
+		{"invalid-name-4", fields{false, AllClientSupportedActionMasks}, args{"Subject💣", "Test"}, nil, true},
+		{"invalid-name-5", fields{false, AllClientSupportedActionMasks}, args{"", "Test"}, nil, true},
+		{"fixup-value-1", fields{false, AllClientSupportedActionMasks}, args{"Subject", "Test\r\n Line2"}, &wire.Message{Code: wire.Code(wire.ActAddHeader), Data: []byte("Subject\000Test\n Line2\000")}, false},
+		{"fixup-value-2", fields{false, AllClientSupportedActionMasks}, args{"Subject", "Test\u0000ing"}, &wire.Message{Code: wire.Code(wire.ActAddHeader), Data: []byte("Subject\000Test ing\000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.AddHeader(tt.args.name, tt.args.value); (err != nil) != tt.wantErr {
+				t.Errorf("AddHeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_AddRecipient(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		r         string
+		esmtpArgs string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{"", ""}, &wire.Message{Code: wire.Code(wire.ActAddRcpt), Data: []byte("<>\u0000")}, false},
+		{"allowed-args", fields{false, AllClientSupportedActionMasks}, args{"", "A=B"}, &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>\u0000A=B\u0000")}, false},
+		{"allowed-args-2", fields{false, AllClientSupportedActionMasks & ^OptAddRcpt}, args{"", ""}, &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>\u0000\u0000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{"", ""}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{"", ""}, nil, true},
+		{"fixup-1", fields{false, AllClientSupportedActionMasks}, args{"<>", ""}, &wire.Message{Code: wire.Code(wire.ActAddRcpt), Data: []byte("<>\u0000")}, false},
+		{"fixup-2", fields{false, AllClientSupportedActionMasks}, args{"<\u0000>", ""}, &wire.Message{Code: wire.Code(wire.ActAddRcpt), Data: []byte("< >\u0000")}, false},
+		{"fixup-3", fields{false, AllClientSupportedActionMasks}, args{"<>", "\u0000"}, &wire.Message{Code: wire.Code(wire.ActAddRcptPar), Data: []byte("<>\u0000 \u0000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.AddRecipient(tt.args.r, tt.args.esmtpArgs); (err != nil) != tt.wantErr {
+				t.Errorf("AddRecipient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddRecipient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_ChangeFrom(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		value     string
+		esmtpArgs string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{"", ""}, &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000")}, false},
+		{"allowed-args", fields{false, AllClientSupportedActionMasks}, args{"", "A=B"}, &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000A=B\u0000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{"", ""}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{"", ""}, nil, true},
+		{"fixup-1", fields{false, AllClientSupportedActionMasks}, args{"<>", ""}, &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000")}, false},
+		{"fixup-2", fields{false, AllClientSupportedActionMasks}, args{"<\u0000>", ""}, &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("< >\u0000")}, false},
+		{"fixup-3", fields{false, AllClientSupportedActionMasks}, args{"<>", "\u0000"}, &wire.Message{Code: wire.Code(wire.ActChangeFrom), Data: []byte("<>\u0000 \u0000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.ChangeFrom(tt.args.value, tt.args.esmtpArgs); (err != nil) != tt.wantErr {
+				t.Errorf("ChangeFrom() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ChangeFrom() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_ChangeHeader(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		index int
+		name  string
+		value string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{1, "Subject", "Test"}, &wire.Message{Code: wire.Code(wire.ActChangeHeader), Data: []byte("\u0000\u0000\u0000\u0001Subject\000Test\000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{1, "Subject", "Test"}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{1, "Subject", "Test"}, nil, true},
+		{"invalid-index-1", fields{false, AllClientSupportedActionMasks}, args{-1, "Subject:", "Test"}, nil, true},
+		{"invalid-index-2", fields{false, AllClientSupportedActionMasks}, args{math.MaxUint32 + 1, "Subject:", "Test"}, nil, true},
+		{"invalid-name-1", fields{false, AllClientSupportedActionMasks}, args{1, "Subject:", "Test"}, nil, true},
+		{"invalid-name-2", fields{false, AllClientSupportedActionMasks}, args{1, " Subject", "Test"}, nil, true},
+		{"invalid-name-3", fields{false, AllClientSupportedActionMasks}, args{1, "Subj\u0000ect", "Test"}, nil, true},
+		{"invalid-name-4", fields{false, AllClientSupportedActionMasks}, args{1, "Subject💣", "Test"}, nil, true},
+		{"invalid-name-5", fields{false, AllClientSupportedActionMasks}, args{1, "", "Test"}, nil, true},
+		{"fixup-value-1", fields{false, AllClientSupportedActionMasks}, args{1, "Subject", "Test\r\n Line2"}, &wire.Message{Code: wire.Code(wire.ActChangeHeader), Data: []byte("\u0000\u0000\u0000\u0001Subject\000Test\n Line2\000")}, false},
+		{"fixup-value-2", fields{false, AllClientSupportedActionMasks}, args{1, "Subject", "Test\u0000ing"}, &wire.Message{Code: wire.Code(wire.ActChangeHeader), Data: []byte("\u0000\u0000\u0000\u0001Subject\000Test ing\000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.ChangeHeader(tt.args.index, tt.args.name, tt.args.value); (err != nil) != tt.wantErr {
+				t.Errorf("ChangeHeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ChangeHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_DeleteRecipient(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		r string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{""}, &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("<>\u0000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{""}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{""}, nil, true},
+		{"fixup-1", fields{false, AllClientSupportedActionMasks}, args{"<>"}, &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("<>\u0000")}, false},
+		{"fixup-2", fields{false, AllClientSupportedActionMasks}, args{"<\u0000>"}, &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("< >\u0000")}, false},
+		{"fixup-3", fields{false, AllClientSupportedActionMasks}, args{"<\r\n>"}, &wire.Message{Code: wire.Code(wire.ActDelRcpt), Data: []byte("< >\u0000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.DeleteRecipient(tt.args.r); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteRecipient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteRecipient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_InsertHeader(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		index int
+		name  string
+		value string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{1, "Subject", "Test"}, &wire.Message{Code: wire.Code(wire.ActInsertHeader), Data: []byte("\u0000\u0000\u0000\u0001Subject\000Test\000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{1, "Subject", "Test"}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{1, "Subject", "Test"}, nil, true},
+		{"invalid-index-1", fields{false, AllClientSupportedActionMasks}, args{-1, "Subject:", "Test"}, nil, true},
+		{"invalid-index-2", fields{false, AllClientSupportedActionMasks}, args{math.MaxUint32 + 1, "Subject:", "Test"}, nil, true},
+		{"invalid-name-1", fields{false, AllClientSupportedActionMasks}, args{1, "Subject:", "Test"}, nil, true},
+		{"invalid-name-2", fields{false, AllClientSupportedActionMasks}, args{1, " Subject", "Test"}, nil, true},
+		{"invalid-name-3", fields{false, AllClientSupportedActionMasks}, args{1, "Subj\u0000ect", "Test"}, nil, true},
+		{"invalid-name-4", fields{false, AllClientSupportedActionMasks}, args{1, "Subject💣", "Test"}, nil, true},
+		{"invalid-name-5", fields{false, AllClientSupportedActionMasks}, args{1, "", "Test"}, nil, true},
+		{"fixup-value-1", fields{false, AllClientSupportedActionMasks}, args{1, "Subject", "Test\r\n Line2"}, &wire.Message{Code: wire.Code(wire.ActInsertHeader), Data: []byte("\u0000\u0000\u0000\u0001Subject\000Test\n Line2\000")}, false},
+		{"fixup-value-2", fields{false, AllClientSupportedActionMasks}, args{1, "Subject", "Test\u0000ing"}, &wire.Message{Code: wire.Code(wire.ActInsertHeader), Data: []byte("\u0000\u0000\u0000\u0001Subject\000Test ing\000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.InsertHeader(tt.args.index, tt.args.name, tt.args.value); (err != nil) != tt.wantErr {
+				t.Errorf("InsertHeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("InsertHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_Progress(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, &wire.Message{Code: wire.Code(wire.ActProgress)}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, &wire.Message{Code: wire.Code(wire.ActProgress)}, false},
+		{"not-negotiated", fields{false, 0}, &wire.Message{Code: wire.Code(wire.ActProgress)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.Progress(); (err != nil) != tt.wantErr {
+				t.Errorf("Progress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Progress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_Quarantine(t *testing.T) {
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		reason string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{"reason"}, &wire.Message{Code: wire.Code(wire.ActQuarantine), Data: []byte("reason\u0000")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{""}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{""}, nil, true},
+		{"fixup-1", fields{false, AllClientSupportedActionMasks}, args{"reason\u0000"}, &wire.Message{Code: wire.Code(wire.ActQuarantine), Data: []byte("reason \u0000")}, false},
+		{"fixup-2", fields{false, AllClientSupportedActionMasks}, args{"reason\r\nline2"}, &wire.Message{Code: wire.Code(wire.ActQuarantine), Data: []byte("reason line2\u0000")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.Quarantine(tt.args.reason); (err != nil) != tt.wantErr {
+				t.Errorf("Quarantine() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Quarantine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_ReplaceBodyRawChunk(t *testing.T) {
+
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		chunk []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{[]byte("body")}, &wire.Message{Code: wire.Code(wire.ActReplBody), Data: []byte("body")}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{[]byte("body")}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{[]byte("body")}, nil, true},
+		{"nul-allowed", fields{false, AllClientSupportedActionMasks}, args{[]byte("body\u0000with-nul")}, &wire.Message{Code: wire.Code(wire.ActReplBody), Data: []byte("body\u0000with-nul")}, false},
+		{"too-big", fields{false, AllClientSupportedActionMasks}, args{bytes.Repeat([]byte("0123456789ABCDEF"), 4480)}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *wire.Message
+			writePacket := func(msg *wire.Message) error {
+				got = msg
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			if err := m.ReplaceBodyRawChunk(tt.args.chunk); (err != nil) != tt.wantErr {
+				t.Errorf("ReplaceBodyRawChunk() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReplaceBodyRawChunk() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifier_ReplaceBody(t *testing.T) {
+	bigBody := bytes.Repeat([]byte("0123456789ABCDEF"), 4480) // 16 * 4480 = 71680 = 70 KiB
+	bigBodyPkt1 := bigBody[0:DataSize64K]
+	bigBodyPkt2 := bigBody[DataSize64K:]
+	type fields struct {
+		readOnly bool
+		actions  OptAction
+	}
+	type args struct {
+		writes [][]byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*wire.Message
+		wantErr bool
+	}{
+		{"allowed", fields{false, AllClientSupportedActionMasks}, args{[][]byte{[]byte(("body"))}}, []*wire.Message{{Code: wire.Code(wire.ActReplBody), Data: []byte("body")}}, false},
+		{"read-only", fields{true, AllClientSupportedActionMasks}, args{[][]byte{[]byte(("body"))}}, nil, true},
+		{"not-negotiated", fields{false, 0}, args{[][]byte{[]byte(("body"))}}, nil, true},
+		{"least-packets", fields{false, AllClientSupportedActionMasks}, args{[][]byte{[]byte("body"), []byte(("body"))}}, []*wire.Message{{Code: wire.Code(wire.ActReplBody), Data: []byte("bodybody")}}, false},
+		{"spill-over", fields{false, AllClientSupportedActionMasks}, args{[][]byte{bigBody}}, []*wire.Message{{Code: wire.Code(wire.ActReplBody), Data: bigBodyPkt1}, {Code: wire.Code(wire.ActReplBody), Data: bigBodyPkt2}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []*wire.Message
+			writePacket := func(msg *wire.Message) error {
+				cpy := &wire.Message{Code: msg.Code, Data: make([]byte, len(msg.Data))}
+				copy(cpy.Data, msg.Data)
+				got = append(got, cpy)
+				return nil
+			}
+			wp := writePacket
+			if tt.fields.readOnly {
+				wp = errorWriteReadOnly
+			}
+			m := &Modifier{
+				Macros:              NewMacroBag(),
+				writeProgressPacket: writePacket,
+				writePacket:         wp,
+				actions:             tt.fields.actions,
+				maxDataSize:         DataSize64K,
+			}
+			r, w := io.Pipe()
+			go func() {
+				var err error
+				for _, r := range tt.args.writes {
+					_, err = w.Write(r)
+					if err != nil {
+						break
+					}
+				}
+				_ = w.CloseWithError(err)
+			}()
+			if err := m.ReplaceBody(r); (err != nil) != tt.wantErr {
+				t.Errorf("ReplaceBody() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Got:")
+				for i, m := range got {
+					t.Error(fmt.Sprintf("%d - len %d\n", i, len(m.Data)) + hex.Dump(m.Data))
+				}
+				t.Errorf("Want:")
+				for i, m := range tt.want {
+					t.Error(fmt.Sprintf("%d - len %d\n", i, len(m.Data)) + hex.Dump(m.Data))
+				}
+			}
+		})
+	}
+}

--- a/response_test.go
+++ b/response_test.go
@@ -32,7 +32,7 @@ func TestRejectWithCodeAndReason(t *testing.T) {
 		{"Newline4", args{400, "\n\r"}, "400 ", false},
 		{"%", args{400, "%"}, "400 %%", false},
 		{"Multi invalid EEC", args{400, "5.7.1 go away\r\nreally!"}, "400-5.7.1 go away\r\n400 really!", false},
-		{"null-bytes", args{400, "bogus\x00reason"}, "", true},
+		{"null-bytes", args{400, "bogus\x00reason"}, "400 bogus reason", false},
 		{"invalid-code1", args{200, ""}, "", true},
 		{"invalid-code2", args{999, ""}, "", true},
 		{"too-big", args{400, tooBig}, "", true},

--- a/server_test.go
+++ b/server_test.go
@@ -2,7 +2,9 @@ package milter
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/d--j/go-milter/internal/wire"
 	"github.com/emersion/go-message/textproto"
@@ -72,7 +74,7 @@ func TestServer_NoOpMilter(t *testing.T) {
 	w := newServerClient(t, macros, []Option{WithMilter(func() Milter {
 		return NoOpMilter{}
 	})}, nil)
-	defer w.Cleanup()
+	t.Cleanup(w.Cleanup)
 	macros.Set(MacroMTAFQDN, "localhost.local")
 	macros.Set(MacroTlsVersion, "TLS1.3")
 	macros.Set(MacroAuthType, "plain")
@@ -111,5 +113,78 @@ func TestServer_NoOpMilter(t *testing.T) {
 	assertEnd(w.session.End())
 	if err := w.server.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestServer_Shutdown(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		mod func(wrap *serverClientWrap)
+		ctx func() (context.Context, context.CancelFunc)
+	}
+	oneSecCtx := func() (context.Context, context.CancelFunc) {
+		return context.WithTimeout(context.Background(), time.Second)
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"active", args{func(wrap *serverClientWrap) {
+			// newServerClient opens a session
+		}, oneSecCtx}, true},
+		{"idle", args{func(wrap *serverClientWrap) {
+			_ = wrap.session.Close()
+			time.Sleep(time.Millisecond * 100)
+		}, oneSecCtx}, false},
+		{"graceful", args{func(w *serverClientWrap) {
+			go func() {
+				if _, err := w.session.Conn("localhost", FamilyInet, 2525, "127.0.0.1"); err != nil {
+					return
+				}
+				if _, err := w.session.Helo("localhost"); err != nil {
+					return
+				}
+				if _, err := w.session.Mail("", ""); err != nil {
+					return
+				}
+				if _, err := w.session.Rcpt("", ""); err != nil {
+					return
+				}
+				if _, err := w.session.DataStart(); err != nil {
+					return
+				}
+				if _, err := w.session.HeaderField("From", "<>", nil); err != nil {
+					return
+				}
+				if _, err := w.session.HeaderField("To", "<>", nil); err != nil {
+					return
+				}
+				if _, err := w.session.HeaderEnd(); err != nil {
+					return
+				}
+				if _, err := w.session.BodyChunk([]byte("test\n")); err != nil {
+					return
+				}
+				if _, _, err := w.session.End(); err != nil {
+					return
+				}
+			}()
+		}, oneSecCtx}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := newServerClient(t, NewMacroBag(), []Option{WithMilter(func() Milter {
+				return NoOpMilter{}
+			})}, nil)
+			t.Cleanup(w.Cleanup)
+			tt.args.mod(&w)
+			ctx, cancel := tt.args.ctx()
+			defer cancel()
+			if err := w.server.Shutdown(ctx); (err != nil) != tt.wantErr {
+				t.Errorf("Shutdown() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/session_test.go
+++ b/session_test.go
@@ -129,7 +129,9 @@ func Test_milterSession_negotiate(t *testing.T) {
 		t.Run(tt_.name, func(t *testing.T) {
 			tt := tt_
 			t.Parallel()
-			m := &serverSession{}
+			m := &serverSession{shuttingDown: func() bool {
+				return false
+			}}
 			milterVersion := tt.fields.milterVersion
 			if milterVersion == 0 {
 				milterVersion = MaxServerProtocolVersion
@@ -530,6 +532,9 @@ func Test_milterSession_Process(t *testing.T) {
 				protocol: tt.fields.protocol,
 				macros:   newMacroStages(),
 				backend:  tt.fields.backend,
+				shuttingDown: func() bool {
+					return false
+				},
 			}
 			gotR, err := m.Process(tt.msg)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
The last release unfortunately was a little bit premature. This PR fixes mailfilter.QuarantineResponse and refactors mailfilter.Decision to include some helpers you can include in logging and testing code.

It also introduces Shutdown(context.Context) functions (for milter.Server and mailfilter.Mailfilter) for graceful shutdown of the milter.

mailfilter.Mailfilter got new options WIthBody and WithHeader that configure the maximum allowed header count and body size.

mailfilter.Trx has a new function Data that cen be used to get the full eMail message (header & body) – with all modifications you might have made to the headers and the body.