### PR TITLE
fix: preserve MTA session state between messages

### DIFF
--- a/mailfilter/backend.go
+++ b/mailfilter/backend.go
@@ -275,9 +275,9 @@ func (b *backend) BodyChunk(chunk []byte, m milter.Modifier) (*milter.Response, 
 
 func (b *backend) readyForNewMessage() {
 	if b.transaction != nil {
-		connect, helo := b.transaction.connect, b.transaction.helo
+		mta, connect, helo := b.transaction.mta, b.transaction.connect, b.transaction.helo
 		b.Cleanup(nil)
-		b.transaction.connect, b.transaction.helo = connect, helo
+		b.transaction.mta, b.transaction.connect, b.transaction.helo = mta, connect, helo
 	} else {
 		b.Cleanup(nil)
 	}


### PR DESCRIPTION
`readyForNewMessage` currently preserves connection and HELO state when reusing the same SMTP/milter session for another message. However, it drops the MTA state, including `MacroMTAFQDN` ("j"), `MacroMTAVersion`, and `MacroDaemonName`.

These values are populated during Connect and describe the MTA/session, not an individual message. Dropping them causes `trx.MTA().FQDN` to be empty for subsequent messages on the same connection (e.g., STARTTLS).